### PR TITLE
Expand agentic ecosystems synthesis and fix valueflows ID

### DIFF
--- a/references/REFERENCE-AGENTS-001-Multi-Dimensional-Agent-Systems.md
+++ b/references/REFERENCE-AGENTS-001-Multi-Dimensional-Agent-Systems.md
@@ -1,110 +1,231 @@
-# REFERENCE-AGENTS-001 - Multi-Dimensional Agent Systems - Working View
+# REFERENCE-AGENTS-001 - Agentic Ecosystems - Working Synthesis
 
-- ID: REFERENCE-AGENTS-001
-- Status: Reference  
-- Created: 2026-04-03  
-- Updated: 2026-04-11  
-
----
+- **ID:** REFERENCE-AGENTS-001
+- **Status:** Working Draft
+- **Created:** 2026-04-03
+- **Updated:** 2026-04-11
 
 ## Intent
 
-Capture that agent capability (autonomy, count, orchestration) is only one dimension of system design. Milieu requires additional dimensions to safely and meaningfully operate agent systems.
+Capture the current working synthesis that agent systems are multi-dimensional, and that agentic ecosystems are not defined only by agent capability or count, but by how human agents, AI agents, and system agents coordinate across governance, operations, change, carried context, validation, authority, and memory over time.
 
----
+This reference exists to preserve the broader working theory emerging in Milieu without prematurely splitting that theory into too many narrower records.
 
-## Summary
+## Context
 
-Current discourse on AI systems often focuses on increasing agent capability:
-- more autonomy
-- more agents
-- more orchestration
+Milieu is not designing isolated agent tasks.
 
-This is useful, but incomplete.
+It is developing ecosystems in which human agents, AI agents, and system agents contribute across shared artifacts, repositories, branches, pull requests, runtime systems, and future public experiences.
 
-High capability without supporting structure leads to instability.  
-Structure without capability leads to stagnation.
+Current Milieu work already assumes that:
 
-Milieu explores systems that maintain both.
+- stakeholders act through agents
+- agent action must be bounded and observable
+- shared artifacts evolve through explicit proposal and acceptance
+- later agents must be able to continue work without pretending to share the same original context
+- continuity cannot be tied permanently to one tool, one interface, or one representation
 
----
+These patterns suggest that agent capability alone is not enough to explain system behavior.
 
-## Primary Dimensions (Working Set)
+## Working Synthesis
 
-These dimensions are not yet formalized. They are observed and evolving.
+Agent systems are multi-dimensional.
 
-### 1. Agency
+Increasing autonomy, count, or orchestration may increase capability, but does not by itself produce a stable, legible, or trustworthy ecosystem.
+
+The present synthesis expands that view by focusing not only on dimensions in the abstract, but on the practical coordination requirements of an agentic ecosystem.
+
+A workable agentic ecosystem must coordinate:
+
+- what can act
+- how authority is bounded
+- how work moves
+- how context moves
+- how outputs become trustworthy
+- how continuity is preserved
+
+These dimensions are interdependent.
+
+Weakness in one dimension often appears as overload, confusion, or hidden assumptions in another.
+
+## Dimensions
+
+### Agency
+
 What can act.
+
+This includes:
+
 - human agents
 - AI agents
 - system agents
-- degree of autonomy
+- degrees of autonomy
 - orchestration complexity
 
-### 2. Governance
-Who is allowed to act, and under what authority.
-- role definition
-- boundaries of action
-- conflict resolution
-- stewardship judgment and policy
+Agency describes the presence and capability of actors, but not yet the quality of their coordination.
 
-### 3. Operations
-How the system runs.
-- environments (development, build, runtime)
-- reproducibility
-- deployment and control planes
-- system agents executing work
+### Governance and Authority
 
-### 4. Change
-How the system evolves.
-- change proposals (e.g., pull requests)
-- review across agent types
-- traceability of intent and outcome
-- safe iteration
+How action is bounded, interpreted, and held accountable.
 
-### 5. Validation
-How outcomes are evaluated.
-- technical correctness
-- experiential quality
-- feedback models
-- learning loops
+This includes:
 
-### 6. Memory
+- who may request change
+- who may implement change
+- who may review change
+- who may accept change
+- who acts as steward or boundary-holder when shared risk is involved
+
+Governance is not separate from agent systems.
+
+It shapes what kinds of action are legitimate, reviewable, and acceptable.
+
+### Operations and Working Surfaces
+
+How the ecosystem runs in practice.
+
+This includes environments and surfaces such as:
+
+- repositories
+- branches
+- pull requests
+- records
+- local working copies
+- build systems
+- runtime systems
+- logs and related operational outputs
+
+Operations provide the practical surfaces through which agents act, inspect, and coordinate.
+
+### Change, Collaboration, Review, and Learning
+
+How work moves through the ecosystem.
+
+This includes:
+
+- collaborative development of candidate changes
+- review of outputs against intent and constraints
+- learning from outcomes to improve future prompts, tools, records, and workflows
+- nested and recursive loops within larger changes
+
+A single change may contain multiple smaller loops.
+
+Different loops may have different requesters, implementers, reviewers, and acceptance boundaries.
+
+### Carried Context and Handoffs
+
+How understanding moves between agents and working surfaces.
+
+This includes continuity across:
+
+- conversations
+- records
+- repository files
+- branches
+- pull requests
+- logs
+- build outputs
+- screenshots, video, and other non-text artifacts
+
+Not all context should be carried forward.
+
+The ecosystem must preserve enough context for another agent to continue well without requiring every later agent to load everything.
+
+This dimension is explored further in `REFERENCE-AGENTS-002`.
+
+### Validation, Evidence, and Trust Surfaces
+
+How outputs become trustworthy enough to review or accept.
+
+This includes:
+
+- diffs
+- tests
+- logs
+- screenshots
+- file presence checks
+- direct inspection of artifacts
+- explicit reporting of uncertainty or authority limits
+
+Trust should rely on observable evidence appropriate to the scope of change.
+
+Confidence without evidence is not enough.
+
+### Memory and Continuity
+
 What persists over time.
-- records (DR, ADR, REFERENCE, etc.)
+
+This includes:
+
+- records
 - decision lineage
-- auditability
-- replay and what-if analysis
+- accepted changes
+- validation artifacts
+- preserved assumptions
+- retained open questions
+- reusable patterns for future agents
 
----
+Memory allows later agents to continue work without reconstructing everything from scratch.
 
-## Notes
+## Coupling Between Dimensions
 
-- These dimensions are interdependent.
-- Increasing capability (Agency) without strengthening other dimensions introduces risk.
-- The appropriate balance is context-dependent and must be discovered through practice.
+These dimensions should not be treated as independent checklists.
 
----
+Examples:
 
-## Relationship to Existing Models
+- weak carried context increases review burden
+- weak validation increases pressure to trust identity alone
+- weak authority boundaries create confusion about who may accept change
+- weak memory forces repeated rediscovery
+- high agency without supporting dimensions increases instability
 
-Some models describe increasing agent capability as a progression (e.g., from assistant → delegate → orchestrated agents).
+The ecosystem should therefore be designed for balance rather than maximum autonomy.
 
-This reference treats that progression as only one axis (Agency).
+## Working Patterns Observed So Far
 
-Milieu work explores additional dimensions required for systems composed of multiple agent types operating over time.
+Current Milieu work suggests several early patterns:
 
----
+- requester review is often the best review for intent satisfaction
+- implementation review and boundary review may require different agents
+- shared artifacts reduce hidden assumptions during handoff
+- branch isolation and explicit diffs help bound change surfaces
+- evidence should match the scope of the change
+- missing context should be surfaced rather than invented
+- collaboration loops matter alongside review loops
+- feedback from physical human work must be able to re-enter the shared system
+
+These are working findings, not final doctrine.
+
+## Consequences
+
+This synthesis suggests that Milieu should not evaluate agentic progress only by asking whether agents can do more work.
+
+It should also ask:
+
+- can the ecosystem carry context cleanly
+- can changes be reviewed at the right scope
+- can acceptance rely on visible evidence
+- can authority boundaries be understood
+- can later agents continue work without unnecessary reconstruction
+
+This shifts attention from isolated capability toward ecosystem quality.
 
 ## Open Questions
 
-- What is the minimum viable structure required for stability?
-- Which dimensions must be explicit vs implicit?
-- How do these dimensions map to records and operational artifacts?
-- Where do failure modes emerge as capability increases?
+- What is the minimum viable ecosystem structure required before public-facing experiences are exposed?
+- Which dimensions are most fragile in practice?
+- What context should be carried forward directly, and what should remain as pointers?
+- Which evidence surfaces are sufficient for different classes of change?
+- When should requester, reviewer, and accepter be separated?
+- How should physical human work be reflected back into shared records and agent workflows?
+- Which parts of this synthesis should later be split into their own references?
 
----
+## Related
 
-## Addenda (optional)
-
-None yet.
+- `REFERENCE-AGENTS-000`
+- `REFERENCE-AGENTS-002`
+- `REFERENCE-DOMAIN-000`
+- `DECISION-MILIEU-CORE-000`
+- `DECISION-MILIEU-MVM-000`
+- `DECISION-OPERATIONS-CHANGE-000`
+- `DECISION-OPERATIONS-CHANGE-001`

--- a/references/REFERENCE-AGENTS-VALUEFLOWS-001-Measurement-Types.md
+++ b/references/REFERENCE-AGENTS-VALUEFLOWS-001-Measurement-Types.md
@@ -1,6 +1,6 @@
-# REFERENCE-AGENTS-VALUEFLOWS-001 — Measurement Types for Agent Work and Value Flows
+# REFERENCE-AGENTS-VALUEFLOWS-001 - Measurement Types for Agent Work and Value Flows
 
-- **ID:** REFERENCE-AGENTS-001
+- **ID:** REFERENCE-AGENTS-VALUEFLOWS-001
 - **Status:** Working Draft
 - **Created:** 2026-03-11
 - **Updated:** 2026-04-11


### PR DESCRIPTION
## Intent

This PR substantially expands `REFERENCE-AGENTS-001` from a thinner note about multi-dimensional agent systems into a broader working synthesis of agentic ecosystems in Milieu.

The edit is large because it is not only a wording pass. It broadens the scope of the note, reconnects dimensions that were previously too thin or implicit, and turns a compact taxonomy into a fuller synthesis with clearer consequences for how Milieu reasons about coordination, trust, and continuity across agents.

## Scope

### Primary change: expand `REFERENCE-AGENTS-001`

`REFERENCE-AGENTS-001` now keeps the original multi-dimensional insight while reframing Milieu as working with agentic ecosystems rather than isolated agent tasks.

The revised note treats these as coupled dimensions of the ecosystem:

- agency
- governance and authority
- operations and working surfaces
- change, collaboration, review, and learning
- carried context and handoffs
- validation, evidence, and trust surfaces
- memory and continuity

This shifts the emphasis away from raw agent capability alone and toward ecosystem legibility, trustworthiness, and continuity over time.

### Boundary with `REFERENCE-AGENTS-002`

This PR does **not** fold `REFERENCE-AGENTS-002` into `REFERENCE-AGENTS-001`.

`REFERENCE-AGENTS-002` remains the dedicated carried-context concept note. `REFERENCE-AGENTS-001` now references carried context as one dimension within the larger ecosystem synthesis and points to `REFERENCE-AGENTS-002` as the deeper note on that concept.

Part of why the `001` rewrite grew is that it needed to make the boundary between the broader synthesis and the narrower concept note more explicit and more legible.

### Secondary change: normalize `REFERENCE-AGENTS-VALUEFLOWS-001`

This PR also includes a small document-hygiene fix for `REFERENCE-AGENTS-VALUEFLOWS-001`:

- normalize the record ID to `REFERENCE-AGENTS-VALUEFLOWS-001`
- align the heading delimiter with current record conventions
- remove the prior ID collision with `REFERENCE-AGENTS-001`

This is a secondary cleanup in the same PR, not a co-equal change with the `001` rewrite.

## Interfaces / Non-Goals

No runtime APIs, schemas, or code interfaces change in this PR.

The only interface-level changes are documentation relationships and identity clarity:

- `REFERENCE-AGENTS-001` now explicitly points to `REFERENCE-AGENTS-002`
- the value-flows reference now has a non-colliding identity

This rationale is grounded in the reference and decision layer, not in `AGENTS.md`.

## Commands / Checks Run

Docs-only change. No code tests were applicable.

Verification performed with repo inspection and diff checks, including:

- `git diff --stat -- references/REFERENCE-AGENTS-001-Multi-Dimensional-Agent-Systems.md references/REFERENCE-AGENTS-002-Carried-Context-Working-Concept.md references/REFERENCE-AGENTS-VALUEFLOWS-001-Measurement-Types.md`
- `rg -n "REFERENCE-AGENTS-002|\*\*ID:\*\* REFERENCE-AGENTS-VALUEFLOWS-001" references -S`

## Results / Evidence

Verified from the repo state that:

- `REFERENCE-AGENTS-001` is the only substantive content rewrite in this PR
- `REFERENCE-AGENTS-002` remains unchanged
- `REFERENCE-AGENTS-001` explicitly references `REFERENCE-AGENTS-002`
- `REFERENCE-AGENTS-VALUEFLOWS-001` now uses the corrected ID
- the value-flows fix is secondary to the `001` rewrite

## Rollback Notes

Rollback is straightforward: revert the documentation changes in this PR.

This would restore the prior thinner form of `REFERENCE-AGENTS-001` and undo the value-flows identity normalization. No runtime behavior, schema, or migration rollback is involved.

~ chris + GPT-5.4