### PR TITLE
architecture: introduce ARCHITECTURE-PRISMAL-EXPERIMENT-000 and -001

### DIFF
--- a/architecture/ARCHITECTURE-PRISMAL-000-Prismal-Core-Architecture-Founding.md
+++ b/architecture/ARCHITECTURE-PRISMAL-000-Prismal-Core-Architecture-Founding.md
@@ -3,7 +3,7 @@
 - **ID:** ARCHITECTURE-PRISMAL-000
 - **Status:** Working Draft
 - **Created:** 2026-04-13
-- **Updated:** 2026-04-13
+- **Updated:** 2026-04-14
 
 ## Intent
 
@@ -56,7 +56,7 @@ Core's first responsibility is to answer questions about the substrate correctly
 Any engine or platform that consumes Core must provide:
 
 - a unit scale `a` — the distance in host-space units corresponding to one nearest-neighbor step
-- a coordinate mapping — how Core's current first-implementation integer carrier coordinates map to positions in the host environment
+- a coordinate mapping — how Core's current first-implementation `Z^3` index-space coordinates map to positions in the host environment
 
 Core does not provide these. They are injected by the adapter.
 

--- a/architecture/ARCHITECTURE-PRISMAL-000-Prismal-Core-Architecture-Founding.md
+++ b/architecture/ARCHITECTURE-PRISMAL-000-Prismal-Core-Architecture-Founding.md
@@ -1,0 +1,85 @@
+# ARCHITECTURE-PRISMAL-000 - Prismal Core — Architecture Founding
+
+- **ID:** ARCHITECTURE-PRISMAL-000
+- **Status:** Working Draft
+- **Created:** 2026-04-13
+- **Updated:** 2026-04-13
+
+## Intent
+
+Establish the founding architecture context for all Prismal™ Core library work.
+
+This document is the first anchor in the ARCHITECTURE-PRISMAL family. Agents working on any Prismal Core implementation — regardless of language, engine, or host environment — should read this first.
+
+## Context
+
+The DECISION-PRISMAL family establishes why Prismal Core exists and what it is committed to. This document carries the implementation context that must survive handoff so that work on Core can continue well.
+
+REFERENCE-PRISMAL-001 establishes that Prismal Space is a discrete realization of an underlying continuum. REFERENCE-PRISMAL-003 establishes that named lattice structures are views over a shared substrate, not independent foundational systems. REFERENCE-PRISMAL-GEOMETRY-000 establishes the exact sphere geometry ratios that govern those views. These three references are the primary sources for any agent working on Core.
+
+## What Core Is
+
+Prismal Core is the engine-agnostic library that holds the substrate geometry and lattice view machinery for Prismal Space.
+
+It is not a game engine module. It is not a rendering system. It is not a simulation framework. Those things are adapters and explorations built on top of Core.
+
+Core exists because the substrate geometry and selection logic must be expressible, testable, and reasoned about independently of any engine or platform. If Core cannot be understood and verified without an engine, it is not Core — it has leaked into the adapter layer.
+
+## Foundational Constraints
+
+These constraints apply to all Prismal Core work. They derive from the REFERENCE-PRISMAL family and must not be silently violated by implementations or later documents.
+
+### No engine dependencies
+
+Core must not include engine headers, depend on engine types, or rely on engine lifecycle. This constraint holds even when Core physically lives inside an engine project during early development. Discipline enforces the boundary now; the build system enforces it later when Core moves to a standalone library.
+
+### Nothing implicit
+
+Lattice views, selection rules, and unit scale are explicit parameters passed through the call chain. No global lattice state. No ambient configuration. An agent reading Core code must be able to determine the active lattice view from the call site alone.
+
+This derives directly from REFERENCE-PRISMAL-001's treatment of coordinate systems as projections, not foundations. Making the view implicit would silently encode a foundational assumption that the system explicitly rejects.
+
+### Scale agnosticism
+
+Core operates in units of the nearest-neighbor distance `a`. Physical or simulation scale is injected by the caller. Core contains no hard-coded units. This derives from REFERENCE-PRISMAL-GEOMETRY-000's normalization convention.
+
+### Views are not the substrate
+
+Named lattices — FCC, SC, BCC — are selections over the shared substrate, not independent structures. An implementation that treats them as separate systems has misread the model. REFERENCE-PRISMAL-003 is the authoritative source on this constraint.
+
+### Computation before storage
+
+Core's first responsibility is to answer questions about the substrate correctly. Storage of site state is a separate concern and must not pollute the substrate geometry layer.
+
+## The Adapter Contract
+
+Any engine or platform that consumes Core must provide:
+
+- a unit scale `a` — the distance in host-space units corresponding to one nearest-neighbor step
+- a coordinate mapping — how Core's integer substrate coordinates map to positions in the host environment
+
+Core does not provide these. They are injected by the adapter.
+
+Core must not make assumptions about the host coordinate system. REFERENCE-PRISMAL-001 establishes that coordinate systems are projections, not foundations.
+
+The first adapter is currently being built for Unreal Engine 5 within the PrismalExperimental project. The adapter contract is not yet expressed as a formal interface. It will be formalized when a second host environment is added and the pattern is confirmed by evidence.
+
+## What This Family Does Not Cover
+
+- Host-specific adapter implementations (see ARCHITECTURE-PRISMAL-EXPERIMENT family and future host-specific families)
+- Day-to-day operations for building and running Core (see OPERATIONS domain records when established)
+- Decisions about which lattice view Prismal uses canonically (see DECISION-PRISMAL family)
+- Play, interaction, and exploration systems built on top of Core (see REFERENCE-PRISMAL-INTERACTION family)
+
+## Open Questions
+
+- When Core moves to a standalone library, what is the minimal build system requirement that remains host-agnostic?
+- Should the adapter contract be expressed as a formal interface in Core itself, or left to convention until a second host environment requires it?
+
+## Related
+
+- REFERENCE-PRISMAL-001 — Field, Lattice, and Projection
+- REFERENCE-PRISMAL-003 — Unified Lattice Substrate and Selection Model
+- REFERENCE-PRISMAL-GEOMETRY-000 — Sphere Geometry Derivation
+- ARCHITECTURE-PRISMAL-001 — First Implementation Context
+- ARCHITECTURE-PRISMAL-EXPERIMENT-000 — Test Harness Architecture Founding

--- a/architecture/ARCHITECTURE-PRISMAL-000-Prismal-Core-Architecture-Founding.md
+++ b/architecture/ARCHITECTURE-PRISMAL-000-Prismal-Core-Architecture-Founding.md
@@ -56,7 +56,7 @@ Core's first responsibility is to answer questions about the substrate correctly
 Any engine or platform that consumes Core must provide:
 
 - a unit scale `a` — the distance in host-space units corresponding to one nearest-neighbor step
-- a coordinate mapping — how Core's integer substrate coordinates map to positions in the host environment
+- a coordinate mapping — how Core's current first-implementation integer carrier coordinates map to positions in the host environment
 
 Core does not provide these. They are injected by the adapter.
 

--- a/architecture/ARCHITECTURE-PRISMAL-001-Prismal-Core-First-Implementation-Context.md
+++ b/architecture/ARCHITECTURE-PRISMAL-001-Prismal-Core-First-Implementation-Context.md
@@ -1,0 +1,165 @@
+# ARCHITECTURE-PRISMAL-001 - Prismal Core — First Implementation Context
+
+- **ID:** ARCHITECTURE-PRISMAL-001
+- **Status:** Working Draft
+- **Created:** 2026-04-13
+- **Updated:** 2026-04-13
+
+## Intent
+
+Carry the implementation context needed by any agent to begin building Prismal™ Core — the substrate geometry and lattice view machinery — as the first working library.
+
+This document does not provide a task list. It carries the constraints, relationships, and reasoning that must survive handoff so that implementation decisions are made well rather than made again from scratch.
+
+## Current Home
+
+Prismal Core currently lives inside the PrismalExperimental project as namespaced classes under `Prismal::Core`. The project currently uses Unreal Engine 5, but the Core namespace must have no dependency on it.
+
+This is a pragmatic starting point, not a permanent home. The target state is a standalone library with no host dependencies, usable from any engine or environment. The boundary is enforced by discipline now — Core must not include host engine headers or use host engine types, even while physically residing in a host project.
+
+When Core moves to its own library, nothing in Core should need to change. If something does need to change at that point, the boundary was not being respected during the experimental phase.
+
+## The Substrate
+
+The substrate is `Z^3` — an integer coordinate space. A site is a position in that space:
+
+```
+{ x, y, z } where x, y, z are integers
+```
+
+The substrate itself has no geometry, no scale, and no preferred lattice. It is the space over which selections are made.
+
+This directly expresses REFERENCE-PRISMAL-003's model: the substrate is the structure over which adjacency and neighborhood relationships can be evaluated, prior to any named lattice interpretation.
+
+## The LatticeView
+
+A `LatticeView` is the carried context for all lattice operations. It binds a selection rule to a unit scale and passes explicitly through every call that needs it.
+
+It carries:
+
+- **SelectionRule** — which lattice view is active (FCC, SC, BCC, or future rules)
+- **unitScale** — the value of `a`, the nearest-neighbor distance, in whatever units the caller cares about
+
+`LatticeView` is never implicit state. It is never global. Every lattice operation that depends on it receives it as a parameter.
+
+This constraint exists because REFERENCE-PRISMAL-001 establishes that coordinate systems are projections, not foundations. Making the view implicit would silently encode a foundational assumption that the system explicitly rejects. An agent reading Core code must be able to determine the active lattice view from the call site alone.
+
+The runtime parameterization of `SelectionRule` is a deliberate decision, not a default. It exists because data passing and data storage patterns for views need to be worked through with real usage, and locking to a compile-time selection before that evidence exists would foreclose options that the substrate model explicitly keeps open.
+
+## Selection Rules
+
+A selection rule determines two things for a given substrate site: whether that site participates in the view, and who its neighbors are.
+
+The three rules needed now, and their expressions over `Z^3`:
+
+### FCC
+
+A site `(x, y, z)` participates when `x + y + z ≡ 0 mod 2`.
+
+Its 12 nearest neighbors are all permutations of `(±1, ±1, 0)`:
+
+```
+(+1,+1, 0)  (+1,-1, 0)  (-1,+1, 0)  (-1,-1, 0)
+(+1, 0,+1)  (+1, 0,-1)  (-1, 0,+1)  (-1, 0,-1)
+( 0,+1,+1)  ( 0,+1,-1)  ( 0,-1,+1)  ( 0,-1,-1)
+```
+
+All 12 offsets have `|offset|² = 2` and all preserve the parity constraint — an FCC site's neighbors are always valid FCC sites.
+
+### SC
+
+All sites in `Z^3` participate — no constraint.
+
+6 nearest neighbors: `(±1, 0, 0)`, `(0, ±1, 0)`, `(0, 0, ±1)`.
+
+### BCC
+
+All sites in `Z^3` participate.
+
+8 nearest neighbors: all `(±1, ±1, ±1)`.
+
+BCC can also be understood as two interleaved SC sublattices — `Z^3` and `Z^3 + (1,1,1)` — which is the same structure expressed differently.
+
+### Why three rules, not three structures
+
+SC, BCC, and FCC are not three different data structures. They are three different selections over the same `Z^3` substrate. The substrate does not change. The neighbor function changes. This is the direct expression of REFERENCE-PRISMAL-003's core model, and it is the reason `SelectionRule` is a parameter rather than a type.
+
+## Geometry Ratios
+
+Core carries the exact geometry ratios from REFERENCE-PRISMAL-GEOMETRY-000 as dimensionless constants. These are multiplied by `unitScale` at the call site to produce values in host units.
+
+All quantities are exact closed forms normalized to nearest-neighbor distance `a = 1`. These have been verified computationally.
+
+### Packing radius
+
+```
+r = a / 2
+```
+
+### RD cell metrics (Voronoi cell of FCC)
+
+```
+RD_inradius      = a / 2          // equals packing radius — exact algebraic identity
+RD_midradius     = a / sqrt(2)    // distance to 4-valent vertex; coincides with octahedral void center
+RD_circumradius  = a * sqrt(6)/4  // distance to 3-valent vertex; coincides with tetrahedral void center
+```
+
+The coincidence of RD vertex distances with void centers is not approximate — it is an exact geometric identity. REFERENCE-PRISMAL-GEOMETRY-000 derives this fully.
+
+### Void geometry
+
+```
+// Tetrahedral void (closer, smaller)
+tet_void_distance = a * sqrt(6)/4          // == RD_circumradius exactly
+tet_void_radius   = a * (sqrt(6) - 2) / 4
+
+// Octahedral void (farther, larger)
+oct_void_distance = a / sqrt(2)            // == RD_midradius exactly
+oct_void_radius   = a * (sqrt(2) - 1) / 2
+```
+
+### Critical overlap thresholds
+
+When spheres of radius `R` are placed at each lattice site, the qualitative topology of their union changes at two thresholds:
+
+```
+R = a * sqrt(6)/4  ≈ 0.6124·a   // sphere surface reaches tetrahedral void centers
+R = a / sqrt(2)    ≈ 0.7071·a   // sphere surface reaches octahedral void centers
+```
+
+These thresholds matter for the test harness rendering profiles. REFERENCE-PRISMAL-GEOMETRY-000 covers the full derivation and implications.
+
+## What Core Answers
+
+In this first implementation, Core is asked to answer three categories of questions:
+
+**Membership** — is a given site a valid member of the active view?
+
+**Neighborhood** — who are the neighbors of a given site under the active selection rule?
+
+**Geometry** — what are the metric properties of a given site and its relationships, scaled to the caller's unit system via `unitScale`?
+
+Core does not answer questions about state, occupancy, material, or history. Those concerns belong to layers built on top of Core.
+
+## What Is Not Specified Here
+
+These are intentionally deferred. They will be addressed through later documents or through evidence gathered from the experimental harness.
+
+- Spatial indexing and storage of site state — a separate concern that must not couple to the substrate geometry layer
+- The formal interface for the adapter contract — deferred until a second host environment is needed
+- Higher-dimensional extensions (D4, E8, Leech) — the math is understood and documented in REFERENCE-PRISMAL-GEOMETRY-000; implementation waits until needed
+- The `Selection → View` machinery as a general runtime system — the first implementation handles FCC, SC, BCC as an enumeration; generalization follows from evidence
+
+## Open Questions
+
+- What is the right representation for `SelectionRule` at this stage — an enum, a struct carrying a neighbor-offset table, or a callable? The enum is simplest; the offset table makes neighbor sets data rather than code and is trivially extensible; the callable is most general. The choice affects how easily new rules are added without modifying Core.
+- Should geometry ratio constants live in a dedicated `Prismal::Geometry` namespace or alongside the lattice view machinery?
+- How should the test harness first consume Core — directly, or through the adapter layer from the start? The answer shapes how the adapter boundary is first exercised and whether any violations are caught early.
+
+## Related
+
+- ARCHITECTURE-PRISMAL-000 — Founding document for this family
+- REFERENCE-PRISMAL-001 — Field, Lattice, and Projection
+- REFERENCE-PRISMAL-003 — Unified Lattice Substrate and Selection Model
+- REFERENCE-PRISMAL-GEOMETRY-000 — Sphere Geometry Derivation
+- ARCHITECTURE-PRISMAL-EXPERIMENT-001 — Test Harness First Implementation Context

--- a/architecture/ARCHITECTURE-PRISMAL-001-Prismal-Core-First-Implementation-Context.md
+++ b/architecture/ARCHITECTURE-PRISMAL-001-Prismal-Core-First-Implementation-Context.md
@@ -21,13 +21,15 @@ When Core moves to its own library, nothing in Core should need to change. If so
 
 ## The Substrate
 
-The substrate is `Z^3` — an integer coordinate space. A site is a position in that space:
+For the first implementation, the current computational carrier is `Z^3` — an integer coordinate space. A site is a position in that space:
 
 ```
 { x, y, z } where x, y, z are integers
 ```
 
-The substrate itself has no geometry, no scale, and no preferred lattice. It is the space over which selections are made.
+This is a starting point for implementation, not a final decision about Prismal's canonical representation or structural formalism, which REFERENCE-PRISMAL-003 still leaves open.
+
+The carrier itself has no geometry, no scale, and no preferred lattice. It is the space over which selections are made.
 
 This directly expresses REFERENCE-PRISMAL-003's model: the substrate is the structure over which adjacency and neighborhood relationships can be evaluated, prior to any named lattice interpretation.
 
@@ -82,7 +84,7 @@ BCC can also be understood as two interleaved SC sublattices — `Z^3` and `Z^3 
 
 ### Why three rules, not three structures
 
-SC, BCC, and FCC are not three different data structures. They are three different selections over the same `Z^3` substrate. The substrate does not change. The neighbor function changes. This is the direct expression of REFERENCE-PRISMAL-003's core model, and it is the reason `SelectionRule` is a parameter rather than a type.
+SC, BCC, and FCC are not three different data structures. They are three different selections over the same `Z^3` carrier. The carrier does not change. The neighbor function changes. This is the direct expression of REFERENCE-PRISMAL-003's core model, and it is the reason `SelectionRule` is a parameter rather than a type.
 
 ## Geometry Ratios
 

--- a/architecture/ARCHITECTURE-PRISMAL-001-Prismal-Core-First-Implementation-Context.md
+++ b/architecture/ARCHITECTURE-PRISMAL-001-Prismal-Core-First-Implementation-Context.md
@@ -3,7 +3,7 @@
 - **ID:** ARCHITECTURE-PRISMAL-001
 - **Status:** Working Draft
 - **Created:** 2026-04-13
-- **Updated:** 2026-04-13
+- **Updated:** 2026-04-14
 
 ## Intent
 
@@ -21,7 +21,7 @@ When Core moves to its own library, nothing in Core should need to change. If so
 
 ## The Substrate
 
-For the first implementation, the current computational carrier is `Z^3` — an integer coordinate space. A site is a position in that space:
+For the first implementation, the substrate is modeled over `Z^3` as an integer index space. A site is a position in that space:
 
 ```
 { x, y, z } where x, y, z are integers
@@ -29,7 +29,7 @@ For the first implementation, the current computational carrier is `Z^3` — an 
 
 This is a starting point for implementation, not a final decision about Prismal's canonical representation or structural formalism, which REFERENCE-PRISMAL-003 still leaves open.
 
-The carrier itself has no geometry, no scale, and no preferred lattice. It is the space over which selections are made.
+In this first implementation, `Z^3` is the current space over which selections are made. The substrate itself has no geometry, no scale, and no preferred lattice.
 
 This directly expresses REFERENCE-PRISMAL-003's model: the substrate is the structure over which adjacency and neighborhood relationships can be evaluated, prior to any named lattice interpretation.
 
@@ -84,7 +84,7 @@ BCC can also be understood as two interleaved SC sublattices — `Z^3` and `Z^3 
 
 ### Why three rules, not three structures
 
-SC, BCC, and FCC are not three different data structures. They are three different selections over the same `Z^3` carrier. The carrier does not change. The neighbor function changes. This is the direct expression of REFERENCE-PRISMAL-003's core model, and it is the reason `SelectionRule` is a parameter rather than a type.
+SC, BCC, and FCC are not three different data structures. They are three different selections over the same `Z^3`-modeled substrate. The substrate does not change. The neighbor function changes. This is the direct expression of REFERENCE-PRISMAL-003's core model, and it is the reason `SelectionRule` is a parameter rather than a type.
 
 ## Geometry Ratios
 

--- a/architecture/ARCHITECTURE-PRISMAL-EXPERIMENT-000-Prismal-Experimental-Test-Harness-Architecture.md
+++ b/architecture/ARCHITECTURE-PRISMAL-EXPERIMENT-000-Prismal-Experimental-Test-Harness-Architecture.md
@@ -1,0 +1,75 @@
+# ARCHITECTURE-PRISMAL-EXPERIMENT-000 - Prismal Experimental Test Harness - Architecture Founding
+
+- **ID:** ARCHITECTURE-PRISMAL-EXPERIMENT-000
+- **Status:** Working Draft
+- **Created:** 2026-04-13
+- **Updated:** 2026-04-13
+
+## Intent
+
+Establish the founding architecture context for all experimental test harness work under the Prismal™ project.
+
+This document is the first anchor in the ARCHITECTURE-PRISMAL-EXPERIMENT family. Agents should read this first when working on any test harness implementation, regardless of which engine or platform is currently in use.
+
+## Context
+
+DECISION-PRISMAL-EXPERIMENT-000 established that Prismal development proceeds through constrained experiments organized into three layers: Core, Engine Adapters, and Exploration. DECISION-PRISMAL-EXPERIMENT-001 established that experimental work requires a structured test harness to support profile-based comparison across rendering regimes.
+
+This architecture family carries the implementation context needed to work within those decisions. It does not restate the decisions or their rationale. It exists because the gap between a decision and working code is where shared understanding most often gets lost.
+
+## Scope of This Family
+
+The ARCHITECTURE-PRISMAL-EXPERIMENT family covers:
+
+- the structure of the test harness and its components
+- the constraints that apply to harness implementations
+- the carried context needed by agents implementing or extending the harness
+
+This family is engine-agnostic in principle. The current implementation uses Unreal Engine 5. Future implementations may use other engines. Architecture documents in this family should distinguish clearly between constraints that are universal and constraints that are engine-specific.
+
+## Foundational Constraints
+
+The following constraints apply to all experimental test harness work. They derive from DECISION-PRISMAL-EXPERIMENT-000 and DECISION-PRISMAL-EXPERIMENT-001 and must not be silently violated by later documents or implementations.
+
+### Harness Isolation
+
+The test harness exists to compare Prismal behavior across different conditions. It must not itself become a source of uncontrolled variation.
+
+Harness components must be simple, explicit, and inspectable.
+
+### Profile Explicitness
+
+Rendering and scalability conditions must be applied through named, explicitly defined profiles.
+
+Implicit reliance on editor defaults or ambient state is not permitted.
+
+### Scene Invariance
+
+The scene under test must be identical across profile runs. Only the applied profile may vary between comparison runs.
+
+### Observation Parsability
+
+Observations produced by or during a harness run must be parseable by another agent — human, AI, or system — without requiring access to the originating agent's context.
+
+### Engine as Adapter
+
+The engine is an adapter for Prismal Core, not the source of truth. Harness implementations must not treat engine state or engine defaults as authoritative Prismal state.
+
+## What This Family Does Not Cover
+
+- Prismal Core architecture (see ARCHITECTURE-PRISMAL family)
+- Day-to-day operations for running experiments (see OPERATIONS domain records when established)
+- Engine-specific setup and tooling beyond what is needed to understand implementation constraints
+
+## Open Questions
+
+- Should engine-specific architecture documents live under this family (e.g., ARCHITECTURE-PRISMAL-EXPERIMENT-UE5-000) or should engine specifics be carried within numbered documents like ARCHITECTURE-PRISMAL-EXPERIMENT-001?
+- When does an experimental harness finding warrant promotion to a constraint in this founding document?
+
+## Related
+
+- DECISION-PRISMAL-EXPERIMENT-000 - Initial Architecture Spike and Layering Constraints
+- DECISION-PRISMAL-EXPERIMENT-001 - Prismal Experimental Test Harness
+- ARCHITECTURE-PRISMAL-EXPERIMENT-001 - Test Harness - First Implementation Context
+- REFERENCE-PRISMAL-000 - Prismal Space Current View and Open Questions
+- REFERENCE-PRISMAL-003 - Unified Lattice Substrate and Selection Model

--- a/architecture/ARCHITECTURE-PRISMAL-EXPERIMENT-001-Test-Harness-First-Implementation-Context.md
+++ b/architecture/ARCHITECTURE-PRISMAL-EXPERIMENT-001-Test-Harness-First-Implementation-Context.md
@@ -1,0 +1,161 @@
+# ARCHITECTURE-PRISMAL-EXPERIMENT-001 - Test Harness - First Implementation Context
+
+- **ID:** ARCHITECTURE-PRISMAL-EXPERIMENT-001
+- **Status:** Working Draft
+- **Created:** 2026-04-13
+- **Updated:** 2026-04-13
+
+## Intent
+
+Carry the implementation context needed by any agent — human, AI, or system — to begin implementing the Prismal™ test harness as decided in DECISION-PRISMAL-EXPERIMENT-001.
+
+This document does not repeat the decision rationale. It does not provide a task list. It provides the structural constraints, relationships, and context that must survive handoff so that implementation work can continue well without loss of shared understanding.
+
+## Current Engine Context
+
+The current implementation uses Unreal Engine 5.7, within the PrismalExperimental project.
+
+This is a contingent fact, not a foundational constraint. Future harness implementations may use other engines. Constraints in this document that are universal are marked as such. Constraints that are Unreal-specific are marked accordingly.
+
+## Component Structure
+
+The harness consists of two collaborating components. They are separated because their concerns are distinct and because either may need to be replaced or extended independently.
+
+### Harness Controller
+
+The Harness Controller is responsible for applying a named profile to the current session and reporting that a profile has been applied.
+
+Its concerns are:
+
+- knowing which profiles exist
+- applying the correct conditions for a named profile
+- making the active profile observable (logged, visible, or otherwise inspectable)
+
+It is not responsible for camera movement, scene setup, or observation capture.
+
+**Universal constraint:** the Harness Controller must apply profiles explicitly. It must not read or rely on ambient engine state.
+
+**UE5 constraint:** profile application is implemented through Scalability settings and Console Variable (CVar) overrides. These must be set programmatically at runtime, not relied upon from editor project settings.
+
+### Camera Path Actor
+
+The Camera Path Actor is responsible for moving through a defined sequence of positions and orientations so that identical viewpoints are observed under each profile.
+
+Its concerns are:
+
+- holding a defined sequence of transforms
+- executing that sequence deterministically
+- signaling when a sequence is complete
+
+It is not responsible for profile application or observation capture.
+
+**Universal constraint:** the camera path must be fully deterministic. Given the same sequence definition, the path must produce identical viewpoints on every run.
+
+## Profile Schema
+
+Each named profile defines a complete set of rendering and scalability conditions. A profile is not a delta from a default — it is a full specification.
+
+Current profiles required by DECISION-PRISMAL-EXPERIMENT-001:
+
+### Reference Profile
+
+Represents the highest-fidelity rendering conditions available in the current environment.
+
+- Lumen: enabled
+- Nanite: enabled
+- Scalability: high (engine quality group 3 or equivalent)
+
+Purpose: establish the visual baseline against which reduced profiles are compared.
+
+### Structural Profile
+
+Represents a reduced rendering configuration that removes or minimizes dynamic global illumination contributions, to isolate Prismal structural legibility from lighting quality.
+
+- Lumen: disabled or contribution minimized
+- Nanite: disabled or non-Nanite geometry used where relevant
+- Scalability: reduced (engine quality group 1 or equivalent)
+
+Purpose: test whether Prismal representations remain legible and interpretable without high-fidelity rendering.
+
+### Degraded Profile (optional)
+
+Represents an aggressively reduced configuration for stress testing.
+
+- Rendering support: minimal
+- Scalability: lowest available
+
+Purpose: surface any hard dependencies on rendering features that are not apparent at the Structural level.
+
+## CVar Reference (UE5-specific)
+
+The following console variables are the current implementation mechanism for Lumen and Nanite control. This list is a working reference, not a complete specification. Agents implementing the harness should verify current UE5 documentation for their engine version.
+
+Lumen control:
+
+- `r.Lumen.Reflections.Allow` — set to 0 to disable Lumen reflections
+- `r.Lumen.DiffuseIndirect.Allow` — set to 0 to disable Lumen diffuse indirect
+- `r.DynamicGlobalIlluminationMethod` — set to 0 for None, 1 for Lumen
+
+Nanite control:
+
+- `r.Nanite.ProjectEnabled` — set to 0 to disable Nanite globally for the session
+
+Scalability groups (UE5 `Scalability::SetQualityLevels`):
+
+- `sg.ShadowQuality`, `sg.TextureQuality`, `sg.PostProcessQuality`, `sg.EffectsQuality`, `sg.FoliageQuality`, `sg.ShadingQuality`
+- Values: 0 (low), 1 (medium), 2 (high), 3 (epic/cinematic)
+
+**Constraint:** CVar values must be applied after engine initialization and before the first rendered frame of the test sequence. Timing of application must be explicit and verifiable.
+
+## Observation Output
+
+Each harness run must produce output that is parseable by another agent without access to the originating agent's session context.
+
+Minimum required per run:
+
+- profile name applied
+- engine and project version
+- timestamp
+- one or more viewpoint captures (screenshots or equivalent)
+- a stub observation record ready for interpretation
+
+The stub observation record format is not yet formalized. Until it is, the minimum is a markdown file containing the above fields with interpretation left blank.
+
+This is intentionally minimal. Formalization is deferred until patterns emerge from actual use.
+
+## Relationships Between Components
+
+The Harness Controller and Camera Path Actor are independent actors. They coordinate through a simple sequencing contract:
+
+1. Harness Controller applies profile
+2. Harness Controller signals ready
+3. Camera Path Actor executes sequence
+4. Camera Path Actor signals complete
+5. Observation output is captured
+
+This sequencing must be explicit. Neither component should assume the other has acted without an observable signal.
+
+**UE5 implementation note:** this coordination may be implemented through Blueprint event bindings, a simple C++ delegate, or a controlling Game Mode. The mechanism is not yet decided. What must be preserved is that the sequencing is observable and not implicit.
+
+## What Is Not Specified Here
+
+The following are intentionally deferred. They will be addressed in later documents, OPERATIONS records, or through the decisions that emerge from actual harness runs.
+
+- Exact class names and file locations (these belong in code and code comments, not here)
+- Automated comparison or regression tooling
+- Integration with Gauntlet or other test frameworks
+- Repository structure for storing observation outputs
+- The formalized observation record format
+
+## Open Questions
+
+- Should the Camera Path Actor hold its transform sequence as a data asset, or as inline UPROPERTY values? The tradeoff is editor visibility versus simplicity.
+- What is the right signal mechanism between Harness Controller and Camera Path Actor given that the project currently has no custom subsystems?
+- Should observation stubs be committed to the PrismalExperimental repo or to milieu-public?
+
+## Related
+
+- ARCHITECTURE-PRISMAL-EXPERIMENT-000 - Founding document for this family
+- DECISION-PRISMAL-EXPERIMENT-001 - Prismal Experimental Test Harness
+- DECISION-PRISMAL-EXPERIMENT-000 - Initial Architecture Spike and Layering Constraints
+- REFERENCE-DEVEX-UNREAL-000 - Developer Experience for Unreal Engine


### PR DESCRIPTION
## Summary

This PR introduces the `architecture/` directory and creates the first two documents in the `ARCHITECTURE-PRISMAL-EXPERIMENT` family.

## Documents

### ARCHITECTURE-PRISMAL-EXPERIMENT-000
Founding anchor for the test harness architecture family. Engine-agnostic. Establishes the foundational constraints that apply to all experimental harness work — harness isolation, profile explicitness, scene invariance, observation parsability, and the engine-as-adapter principle. Agents working on any test harness implementation should read this first.

### ARCHITECTURE-PRISMAL-EXPERIMENT-001
First implementation context bundle. Carries the structural constraints, component relationships, profile schema, UE5 CVar reference, and observation output requirements needed by any agent beginning harness implementation. Explicitly marks what is universal vs. UE5-specific. Does not provide a task list — agents are expected to derive their own.

## Open Questions (surfaced in documents)

- Should engine-specific architecture live under a sub-family (e.g., `ARCHITECTURE-PRISMAL-EXPERIMENT-UE5-000`) or stay within numbered documents in this family?
- Should the Camera Path Actor hold its transform sequence as a data asset or inline UPROPERTYs?
- What is the right signal mechanism between Harness Controller and Camera Path Actor given the current project has no custom subsystems?
- Should observation stubs be committed to PrismalExperimental or milieu-public?

## Notes

- Both documents are Working Draft status.
- This PR also raises the question of what belongs in milieu-public vs. a private repo. The current guidance from README is: public by default, steward judgment on exceptions. Nothing in these documents appears to require privacy — the constraints are derivable from public UE5 documentation and existing public DECISION records. Flagging for steward review.
- Drafted collaboratively by Perplexity Computer in a PrismalTestHarness thread, 2026-04-13.

## Related

- DECISION-PRISMAL-EXPERIMENT-001
- DECISION-PRISMAL-EXPERIMENT-000
- REFERENCE-DEVEX-UNREAL-000