### PR TITLE
architecture: add PrismalCore module structure constraint to EXPERIMENT-001

### DIFF
--- a/architecture/ARCHITECTURE-PRISMAL-000-Prismal-Core-Architecture-Founding.md
+++ b/architecture/ARCHITECTURE-PRISMAL-000-Prismal-Core-Architecture-Founding.md
@@ -78,6 +78,7 @@ The first adapter is currently being built for Unreal Engine 5 within the Prisma
 
 ## Related
 
+- REFERENCE-PRISMAL-000 — Prismal Space Current View and Open Questions
 - REFERENCE-PRISMAL-001 — Field, Lattice, and Projection
 - REFERENCE-PRISMAL-003 — Unified Lattice Substrate and Selection Model
 - REFERENCE-PRISMAL-GEOMETRY-000 — Sphere Geometry Derivation

--- a/architecture/ARCHITECTURE-PRISMAL-001-Prismal-Core-First-Implementation-Context.md
+++ b/architecture/ARCHITECTURE-PRISMAL-001-Prismal-Core-First-Implementation-Context.md
@@ -161,6 +161,7 @@ These are intentionally deferred. They will be addressed through later documents
 ## Related
 
 - ARCHITECTURE-PRISMAL-000 — Founding document for this family
+- REFERENCE-PRISMAL-000 — Prismal Space Current View and Open Questions
 - REFERENCE-PRISMAL-001 — Field, Lattice, and Projection
 - REFERENCE-PRISMAL-003 — Unified Lattice Substrate and Selection Model
 - REFERENCE-PRISMAL-GEOMETRY-000 — Sphere Geometry Derivation

--- a/architecture/ARCHITECTURE-PRISMAL-EXPERIMENT-000-Prismal-Experimental-Test-Harness-Architecture.md
+++ b/architecture/ARCHITECTURE-PRISMAL-EXPERIMENT-000-Prismal-Experimental-Test-Harness-Architecture.md
@@ -3,7 +3,9 @@
 - **ID:** ARCHITECTURE-PRISMAL-EXPERIMENT-000
 - **Status:** Working Draft
 - **Created:** 2026-04-13
-- **Updated:** 2026-04-13
+- **Updated:** 2026-04-18
+
+> **Terminology note:** "profile" in this document always means a harness rendering profile — a named set of rendering and scalability conditions applied during a test run. This is distinct from the service sandbox profiles defined in REFERENCE-OPERATIONS-001, which use the same word for a different concept.
 
 ## Intent
 
@@ -13,7 +15,7 @@ This document is the first anchor in the ARCHITECTURE-PRISMAL-EXPERIMENT family.
 
 ## Context
 
-DECISION-PRISMAL-EXPERIMENT-000 established that Prismal development proceeds through constrained experiments organized into three layers: Core, Engine Adapters, and Exploration. DECISION-PRISMAL-EXPERIMENT-001 established that experimental work requires a structured test harness to support profile-based comparison across rendering regimes.
+DECISION-PRISMAL-EXPERIMENT-000 established that Prismal development proceeds through constrained experiments organized into three layers: Core, Engine Adapters, and Exploration. DECISION-PRISMAL-EXPERIMENT-001 established that experimental work requires a structured test harness to support comparison across rendering regimes using named harness rendering profiles.
 
 This architecture family carries the implementation context needed to work within those decisions. It does not restate the decisions or their rationale. It exists because the gap between a decision and working code is where shared understanding most often gets lost.
 
@@ -37,15 +39,15 @@ The test harness exists to compare Prismal behavior across different conditions.
 
 Harness components must be simple, explicit, and inspectable.
 
-### Profile Explicitness
+### Harness Rendering Profile Explicitness
 
-Rendering and scalability conditions must be applied through named, explicitly defined profiles.
+Rendering and scalability conditions must be applied through named, explicitly defined harness rendering profiles.
 
 Implicit reliance on editor defaults or ambient state is not permitted.
 
 ### Scene Invariance
 
-The scene under test must be identical across profile runs. Only the applied profile may vary between comparison runs.
+The scene under test must be identical across harness rendering profile runs. Only the applied harness rendering profile may vary between comparison runs.
 
 ### Observation Parsability
 

--- a/architecture/ARCHITECTURE-PRISMAL-EXPERIMENT-000-Prismal-Experimental-Test-Harness-Architecture.md
+++ b/architecture/ARCHITECTURE-PRISMAL-EXPERIMENT-000-Prismal-Experimental-Test-Harness-Architecture.md
@@ -74,4 +74,5 @@ The engine is an adapter for Prismal Core, not the source of truth. Harness impl
 - DECISION-PRISMAL-EXPERIMENT-001 - Prismal Experimental Test Harness
 - ARCHITECTURE-PRISMAL-EXPERIMENT-001 - Test Harness - First Implementation Context
 - REFERENCE-PRISMAL-000 - Prismal Space Current View and Open Questions
+- REFERENCE-PRISMAL-DEMO-000 - Planet Biome Demo Proposal
 - REFERENCE-PRISMAL-003 - Unified Lattice Substrate and Selection Model

--- a/architecture/ARCHITECTURE-PRISMAL-EXPERIMENT-001-Test-Harness-First-Implementation-Context.md
+++ b/architecture/ARCHITECTURE-PRISMAL-EXPERIMENT-001-Test-Harness-First-Implementation-Context.md
@@ -5,6 +5,8 @@
 - **Created:** 2026-04-13
 - **Updated:** 2026-04-18
 
+> **Terminology note:** "profile" in this document always means a harness rendering profile — a named set of rendering and scalability conditions applied during a test run. This is distinct from the service sandbox profiles defined in REFERENCE-OPERATIONS-001, which use the same word for a different concept.
+
 ## Intent
 
 Carry the implementation context needed by any agent — human, AI, or system — to begin implementing the Prismal™ test harness as decided in DECISION-PRISMAL-EXPERIMENT-001.
@@ -39,17 +41,17 @@ The harness consists of two collaborating components. They are separated because
 
 ### Harness Controller
 
-The Harness Controller is responsible for applying a named profile to the current session and reporting that a profile has been applied.
+The Harness Controller is responsible for applying a named harness rendering profile to the current session and reporting that a profile has been applied.
 
 Its concerns are:
 
-- knowing which profiles exist
-- applying the correct conditions for a named profile
-- making the active profile observable (logged, visible, or otherwise inspectable)
+- knowing which harness rendering profiles exist
+- applying the correct conditions for a named harness rendering profile
+- making the active harness rendering profile observable (logged, visible, or otherwise inspectable)
 
 It is not responsible for camera movement, scene setup, or observation capture.
 
-**Universal constraint:** the Harness Controller must apply profiles explicitly. It must not read or rely on ambient engine state.
+**Universal constraint:** the Harness Controller must apply harness rendering profiles explicitly. It must not read or rely on ambient engine state.
 
 **UE5 constraint:** profile application is implemented through Scalability settings and Console Variable (CVar) overrides. These must be set programmatically at runtime, not relied upon from editor project settings.
 
@@ -67,11 +69,11 @@ It is not responsible for profile application or observation capture.
 
 **Universal constraint:** the camera path must be fully deterministic. Given the same sequence definition, the path must produce identical viewpoints on every run.
 
-## Profile Schema
+## Harness Rendering Profile Schema
 
-Each named profile defines a complete set of rendering and scalability conditions. A profile is not a delta from a default — it is a full specification.
+Each harness rendering profile defines a complete set of rendering and scalability conditions. A harness rendering profile is not a delta from a default — it is a full specification.
 
-Current profiles required by DECISION-PRISMAL-EXPERIMENT-001:
+Current harness rendering profiles required by DECISION-PRISMAL-EXPERIMENT-001:
 
 ### Reference Profile
 
@@ -129,7 +131,7 @@ Each harness run must produce output that is parseable by another agent without 
 
 Minimum required per run:
 
-- profile name applied
+- harness rendering profile name applied
 - engine and project version
 - timestamp
 - one or more viewpoint captures (screenshots or equivalent)
@@ -139,11 +141,13 @@ The stub observation record format is not yet formalized. Until it is, the minim
 
 This is intentionally minimal. Formalization is deferred until patterns emerge from actual use.
 
+Harness observation runs are also expected to produce early evidence toward the open question in REFERENCE-OPERATIONS-001 of how Unreal Engine workflows integrate with Milieu's service sandbox model. Agents working on that question should treat harness observations as a relevant data source.
+
 ## Relationships Between Components
 
 The Harness Controller and Camera Path Actor are independent actors. They coordinate through a simple sequencing contract:
 
-1. Harness Controller applies profile
+1. Harness Controller applies harness rendering profile
 2. Harness Controller signals ready
 3. Camera Path Actor executes sequence
 4. Camera Path Actor signals complete
@@ -176,3 +180,4 @@ The following are intentionally deferred. They will be addressed in later docume
 - DECISION-PRISMAL-EXPERIMENT-001 - Prismal Experimental Test Harness
 - DECISION-PRISMAL-EXPERIMENT-000 - Initial Architecture Spike and Layering Constraints
 - REFERENCE-DEVEX-UNREAL-000 - Developer Experience for Unreal Engine
+- REFERENCE-OPERATIONS-001 - Service Sandbox Profiles

--- a/architecture/ARCHITECTURE-PRISMAL-EXPERIMENT-001-Test-Harness-First-Implementation-Context.md
+++ b/architecture/ARCHITECTURE-PRISMAL-EXPERIMENT-001-Test-Harness-First-Implementation-Context.md
@@ -179,5 +179,7 @@ The following are intentionally deferred. They will be addressed in later docume
 - ARCHITECTURE-PRISMAL-001 - Prismal Core First Implementation Context
 - DECISION-PRISMAL-EXPERIMENT-001 - Prismal Experimental Test Harness
 - DECISION-PRISMAL-EXPERIMENT-000 - Initial Architecture Spike and Layering Constraints
+- REFERENCE-PRISMAL-000 - Prismal Space Current View and Open Questions
+- REFERENCE-PRISMAL-DEMO-000 - Planet Biome Demo Proposal
 - REFERENCE-DEVEX-UNREAL-000 - Developer Experience for Unreal Engine
 - REFERENCE-OPERATIONS-001 - Service Sandbox Profiles

--- a/architecture/ARCHITECTURE-PRISMAL-EXPERIMENT-001-Test-Harness-First-Implementation-Context.md
+++ b/architecture/ARCHITECTURE-PRISMAL-EXPERIMENT-001-Test-Harness-First-Implementation-Context.md
@@ -57,7 +57,7 @@ It is not responsible for camera movement, scene setup, or observation capture.
 
 ### Camera Path Actor
 
-The Camera Path Actor is responsible for moving through a defined sequence of positions and orientations so that identical viewpoints are observed under each profile.
+The Camera Path Actor is responsible for moving through a defined sequence of positions and orientations so that identical viewpoints are observed under each harness rendering profile.
 
 Its concerns are:
 
@@ -65,7 +65,7 @@ Its concerns are:
 - executing that sequence deterministically
 - signaling when a sequence is complete
 
-It is not responsible for profile application or observation capture.
+It is not responsible for harness rendering profile application or observation capture.
 
 **Universal constraint:** the camera path must be fully deterministic. Given the same sequence definition, the path must produce identical viewpoints on every run.
 

--- a/architecture/ARCHITECTURE-PRISMAL-EXPERIMENT-001-Test-Harness-First-Implementation-Context.md
+++ b/architecture/ARCHITECTURE-PRISMAL-EXPERIMENT-001-Test-Harness-First-Implementation-Context.md
@@ -53,7 +53,7 @@ It is not responsible for camera movement, scene setup, or observation capture.
 
 **Universal constraint:** the Harness Controller must apply harness rendering profiles explicitly. It must not read or rely on ambient engine state.
 
-**UE5 constraint:** profile application is implemented through Scalability settings and Console Variable (CVar) overrides. These must be set programmatically at runtime, not relied upon from editor project settings.
+**UE5 constraint:** harness rendering profile application is implemented through Scalability settings and Console Variable (CVar) overrides. These must be set programmatically at runtime, not relied upon from editor project settings.
 
 ### Camera Path Actor
 

--- a/architecture/ARCHITECTURE-PRISMAL-EXPERIMENT-001-Test-Harness-First-Implementation-Context.md
+++ b/architecture/ARCHITECTURE-PRISMAL-EXPERIMENT-001-Test-Harness-First-Implementation-Context.md
@@ -3,7 +3,7 @@
 - **ID:** ARCHITECTURE-PRISMAL-EXPERIMENT-001
 - **Status:** Working Draft
 - **Created:** 2026-04-13
-- **Updated:** 2026-04-13
+- **Updated:** 2026-04-18
 
 ## Intent
 
@@ -15,7 +15,23 @@ This document does not repeat the decision rationale. It does not provide a task
 
 The current implementation uses Unreal Engine 5.7, within the PrismalExperimental project.
 
-This is a contingent fact, not a foundational constraint. Future harness implementations may use other engines. Constraints in this document that are universal are marked as such. Constraints that are Unreal-specific are marked accordingly.
+This is a contingent fact, not a foundational constraint. Future harness implementations may use other engines. Constraints in this document that are universal are marked as such. Constraints that are host-specific are marked accordingly.
+
+## Module Structure
+
+The PrismalExperimental project uses two modules. This structure is a prerequisite for all harness implementation work and must be established before any harness components are written.
+
+**PrismalCore** — a pure C++ module with no host engine dependencies. This is where the substrate geometry and lattice view machinery lives, as specified in ARCHITECTURE-PRISMAL-001. It must not reference PrismalExperimental or any host engine type.
+
+**PrismalExperimental** — the host engine module. This is where the harness components, adapter code, and all UE5-specific implementation lives. It depends on PrismalCore. PrismalCore does not depend on it.
+
+The physical separation into two modules enforces the no-engine-dependencies constraint at build time rather than by convention. This is a deliberate choice: agents are better at respecting structural boundaries than social ones.
+
+When PrismalCore eventually moves to a standalone library, it should require no changes to the Core code itself. If changes are needed at that point, the boundary was not being respected during the experimental phase.
+
+**Universal constraint:** nothing in PrismalCore may include a host engine header or reference a host engine type, even while physically residing in the host project.
+
+**UE5 constraint:** PrismalCore is registered as a separate module in the `.uproject` and has its own `Build.cs`. PrismalExperimental's `Build.cs` lists PrismalCore as a public dependency.
 
 ## Component Structure
 
@@ -156,6 +172,7 @@ The following are intentionally deferred. They will be addressed in later docume
 ## Related
 
 - ARCHITECTURE-PRISMAL-EXPERIMENT-000 - Founding document for this family
+- ARCHITECTURE-PRISMAL-001 - Prismal Core First Implementation Context
 - DECISION-PRISMAL-EXPERIMENT-001 - Prismal Experimental Test Harness
 - DECISION-PRISMAL-EXPERIMENT-000 - Initial Architecture Spike and Layering Constraints
 - REFERENCE-DEVEX-UNREAL-000 - Developer Experience for Unreal Engine


### PR DESCRIPTION
## Summary

Adds a **Module Structure** section to `ARCHITECTURE-PRISMAL-EXPERIMENT-001` ahead of the Rider agent beginning harness implementation work.

## What Changed

A new section between **Current Engine Context** and **Component Structure** that establishes:

- The project requires two modules: `PrismalCore` (pure C++, no host engine dependencies) and `PrismalExperimental` (host engine module, depends on PrismalCore)
- This separation enforces the no-engine-dependencies constraint at build time rather than by convention
- Nothing in PrismalCore may include a host engine header or reference a host engine type, even while physically residing in the host project
- When PrismalCore moves to a standalone library, no Core code should need to change — if it does, the boundary was not respected

Also adds `ARCHITECTURE-PRISMAL-001` to the Related section, which was missing.

## Why Now

The Rider agent is ready to begin module setup. Without this constraint in the document, the boundary between Core and host engine code is implicit — agents are better at respecting structural rules than social ones. This makes it explicit before the first line of implementation is written.

## Context

Discussed and decided in the PrismalTestHarness Computer thread, 2026-04-18.