### PR TITLE
arch(experiment): host-specific language + close engine sub-family naming question

### DIFF
--- a/architecture/ARCHITECTURE-PRISMAL-EXPERIMENT-000-Prismal-Experimental-Test-Harness-Architecture.md
+++ b/architecture/ARCHITECTURE-PRISMAL-EXPERIMENT-000-Prismal-Experimental-Test-Harness-Architecture.md
@@ -3,7 +3,7 @@
 - **ID:** ARCHITECTURE-PRISMAL-EXPERIMENT-000
 - **Status:** Working Draft
 - **Created:** 2026-04-13
-- **Updated:** 2026-04-18
+- **Updated:** 2026-04-19
 
 > **Terminology note:** "profile" in this document always means a harness rendering profile — a named set of rendering and scalability conditions applied during a test run. This is distinct from the service sandbox profiles defined in REFERENCE-OPERATIONS-001, which use the same word for a different concept.
 
@@ -65,8 +65,13 @@ The engine is an adapter for Prismal Core, not the source of truth. Harness impl
 
 ## Open Questions
 
-- Should engine-specific architecture documents live under this family (e.g., ARCHITECTURE-PRISMAL-EXPERIMENT-UE5-000) or should engine specifics be carried within numbered documents like ARCHITECTURE-PRISMAL-EXPERIMENT-001?
 - When does an experimental harness finding warrant promotion to a constraint in this founding document?
+
+## Closed Questions
+
+**Should engine-specific architecture documents use a sub-family (e.g., ARCHITECTURE-PRISMAL-EXPERIMENT-UE5-000) or carry engine specifics within numbered documents?**
+
+Resolved: engine specifics are carried within sections of numbered documents, not in a separate sub-family. Engine-specific content is marked with explicit constraint labels (e.g., **UE5 constraint:**) within the same document. A sub-family would introduce namespace bloat and fragment continuity without providing clarity benefits. If a future engine requires substantially different foundational architecture, this question should be reopened.
 
 ## Related
 

--- a/architecture/ARCHITECTURE-PRISMAL-EXPERIMENT-001-Test-Harness-First-Implementation-Context.md
+++ b/architecture/ARCHITECTURE-PRISMAL-EXPERIMENT-001-Test-Harness-First-Implementation-Context.md
@@ -3,7 +3,7 @@
 - **ID:** ARCHITECTURE-PRISMAL-EXPERIMENT-001
 - **Status:** Working Draft
 - **Created:** 2026-04-13
-- **Updated:** 2026-04-18
+- **Updated:** 2026-04-19
 
 > **Terminology note:** "profile" in this document always means a harness rendering profile — a named set of rendering and scalability conditions applied during a test run. This is distinct from the service sandbox profiles defined in REFERENCE-OPERATIONS-001, which use the same word for a different concept.
 
@@ -25,7 +25,7 @@ The PrismalExperimental project uses two modules. This structure is a prerequisi
 
 **PrismalCore** — a pure C++ module with no host engine dependencies. This is where the substrate geometry and lattice view machinery lives, as specified in ARCHITECTURE-PRISMAL-001. It must not reference PrismalExperimental or any host engine type.
 
-**PrismalExperimental** — the host engine module. This is where the harness components, adapter code, and all UE5-specific implementation lives. It depends on PrismalCore. PrismalCore does not depend on it.
+**PrismalExperimental** — the host engine module. This is where the harness components, adapter code, and all host-specific implementation lives. It depends on PrismalCore. PrismalCore does not depend on it.
 
 The physical separation into two modules enforces the no-engine-dependencies constraint at build time rather than by convention. This is a deliberate choice: agents are better at respecting structural boundaries than social ones.
 


### PR DESCRIPTION
Two small follow-ups from Boss's review of PR #9.

## Changes

### ARCHITECTURE-PRISMAL-EXPERIMENT-001 — Module Structure

- **UE5-specific → host-specific** in the PrismalExperimental module description. The module carries all host-specific implementation, not just UE5-specific implementation. This is consistent with the engine-agnostic framing throughout the document.

### ARCHITECTURE-PRISMAL-EXPERIMENT-000 — Engine sub-family naming

- **Closes the open question:** should engine-specific documents use a sub-family (e.g., `ARCHITECTURE-PRISMAL-EXPERIMENT-UE5-000`) or live as sections within numbered documents?
- **Resolution:** sections within numbered documents, with explicit constraint labels (e.g., **UE5 constraint:**). A sub-family would introduce namespace bloat and fragment continuity without clarity benefit. The question remains reopenable if a future engine requires substantially different foundational architecture.
- Moved from Open Questions to a new Closed Questions section.

## Notes

Single commit. No other content changed.