### PR TITLE
ref(agents): refine coordination model and context publishing proposal

### DIFF
--- a/references/REFERENCE-AGENTS-003-Agent-Coordination-Model.md
+++ b/references/REFERENCE-AGENTS-003-Agent-Coordination-Model.md
@@ -7,31 +7,68 @@
 
 ## Intent
 
-Capture the working coordination model for how human agents, AI agents, and system agents move through the Milieu artifact states together.
+Capture the working coordination model for how human agents, AI agents, and system agents refine shared understanding together.
 
-This reference sits alongside REFERENCE-AGENTS-001 (which describes the dimensions of an agentic ecosystem) and adds the practical coordination layer: how agents actually refine shared understanding across artifact states, what the acceptance gate means, and when system agents emerge.
+This reference sits alongside REFERENCE-AGENTS-001 (which describes the dimensions of an agentic ecosystem) and adds the practical coordination layer: how artifacts move across surfaces, what gates mean, and when system agents emerge.
 
 ## Core Framing
 
-Milieu artifacts — RESOURCE, DECISION, ARCHITECTURE, code — are not pipeline deliverables passed between specialists.
+Milieu artifacts are not pipeline deliverables passed between specialists.
 
-They are **states of shared understanding**.
+They are shared artifacts that may be refined by any agent type.
 
-Any agent type can contribute to any artifact state. What changes across states is what kind of understanding is being refined, not which agent class is permitted to act.
+What changes over time is not which class of agent is allowed to act. What changes is:
+
+- the role the artifact is currently playing
+- the surface on which it is exposed
+- the audience that can observe or act on it
+- what that audience has consented to receive
 
 The actual distribution of work at any moment reflects current capability, not fixed role assignment. Today an AI agent may draft the bulk of an ARCHITECTURE document because that is where it can contribute most. A human agent may catch a constraint the AI missed. A system agent may enforce a boundary the build system understands and no one thought to specify explicitly. Tomorrow those distributions may shift.
 
-## Artifact States
+## Artifacts, Surfaces, and Gates
 
-These are the current states of understanding in the Milieu record system. They are named after the record types that carry them.
+### Artifact
 
-### Proposal (RESOURCE, Issue, or informal artifact)
+An artifact is anything that carries meaning or behavior in the ecosystem.
+
+Examples include documents, code, scripts, configuration, feature flags, tests, notes, issues, and observations from running systems.
+
+### Surface
+
+A surface is the context in which an artifact is exposed.
+
+A surface determines:
+
+- who can observe it
+- who can refine it
+- how directly they can act on it
+- what level of ambiguity, incompleteness, or breakage they have consented to receive
+
+A working branch, an issue thread, a private test harness, a shared reference repository, and a public release are different surfaces.
+
+### Gate
+
+A gate is the point at which an artifact moves to a new surface or becomes visible to a new audience.
+
+The purpose of a gate is not supervision. The purpose of a gate is to make the transition explicit before new agents inherit the artifact.
+
+A pull request merge, a feature flag change, a publication step, or an invitation to an internal alpha group can all function as gates.
+
+## Record Roles Within This Model
+
+The Milieu record system still matters. REFERENCE, DECISION, and ARCHITECTURE are not being discarded.
+
+In this model, they are understood as specialized artifact roles with distinct semantics, not as a strict pipeline with handoffs.
+
+### Proposal
 
 A need, observation, or idea that has not yet been refined into a shared commitment.
 
-The proposal state exists to surface something worth refining. It does not require a specific record type. A GitHub Issue, a REFERENCE document, a conversation thread, or a quick note may all carry a proposal.
+A proposal does not require a specific record type. A GitHub Issue, a REFERENCE document, a conversation thread, a test result, or a quick note may all carry a proposal.
 
-What must survive this state:
+What must survive this role:
+
 - what is being observed or proposed
 - who has standing over it
 - known constraints arriving with it
@@ -39,11 +76,12 @@ What must survive this state:
 
 ### DECISION
 
-The state in which impacted stakeholders have refined a proposal into a shared commitment: what will be done and why, including what was explicitly left out.
+The role in which impacted stakeholders refine a proposal into a shared commitment: what will be done and why, including what was explicitly left out.
 
-A DECISION is not authored by the agent that implements it. It is accepted by the agents with standing over the problem. The authoring agent (human, AI, or system) may produce the draft; acceptance is the act that matters.
+A DECISION is not defined by who authored the draft. It is defined by acceptance from the agents with standing over the problem.
 
-What must survive this state:
+What must survive this role:
+
 - the reasoning, not just the conclusion
 - the constraints that propagate forward
 - what was weighed and set aside
@@ -51,57 +89,77 @@ What must survive this state:
 
 ### ARCHITECTURE
 
-The state in which the accepted commitment is translated into technical constraints and background sufficient for any agent to begin building without reconstructing intent.
+The role in which an accepted commitment is translated into structural and technical constraints sufficient for agents to begin implementation without reconstructing intent.
 
-ARCHITECTURE documents are the primary context carrier for agents beginning implementation work. If an agent cannot observe the relevant ARCHITECTURE document, it should ask for it rather than invent its own constraints.
+ARCHITECTURE artifacts are often the primary carried context for implementation work. If an agent cannot observe the relevant ARCHITECTURE artifact, it should ask for it rather than invent its own constraints.
 
-What must survive this state:
-- the DECISION it implements (explicit relationship)
+What must survive this role:
+
+- the DECISION it implements
 - module or structural boundaries
 - what is host-specific versus genuinely general
 - open questions that remain unresolved
 
-### Code
+### Implementation
 
-The state in which something actually exists and runs.
+The role in which behavior actually exists and can be exercised.
 
-Code is not the end of the loop. Observations from code — build results, test outcomes, unexpected behaviors — feed back into ARCHITECTURE and DECISION. The loop is continuous.
+Implementation may be code, scripts, data transformations, feature flags, configuration, or other executable artifacts.
 
-What must survive this state:
-- which context versions (DECISION, ARCHITECTURE) the code was built against
+Implementation is not automatically final or public. It may exist on a working surface, an internal surface, or a broader exposure surface depending on what audience has consented to receive.
+
+What must survive this role:
+
+- which context versions (REFERENCE, DECISION, ARCHITECTURE, or equivalent) it was built against
 - what was tried and why
-- build and test results as evidence
-- open questions the code revealed
+- test or observation results as evidence
+- open questions the implementation revealed
 
 ## The Loops Are Tight
 
-These states are not phases with handoffs between them. They are positions an artifact can occupy, and agents move artifacts between positions continuously.
+These roles are not fixed phases with handoffs between them.
 
-The loop may run in seconds. An observation during a build may immediately refine an ARCHITECTURE constraint. A constraint in an ARCHITECTURE document may immediately prompt a revision to a DECISION. An agent may skip states in either direction.
+Artifacts may move between roles and surfaces continuously. A build result may immediately refine ARCHITECTURE. A newly observed constraint may immediately refine DECISION. A discussion in a working surface may become REFERENCE. An implementation artifact behind a feature flag may still be serving a working function.
 
-All agents are expected to refine as they go. The record system provides structure; it does not impose process latency.
+The loop may run in seconds. The record system provides structure; it does not impose process latency.
+
+## Working Surfaces and Consent
+
+A working surface is a surface where participants have knowingly consented to receive ambiguity, incompleteness, and possible breakage in exchange for tighter collaborative loops.
+
+That consent matters.
+
+A change that is acceptable on a working surface may be unacceptable on a broader shared surface. The difference is not the artifact itself. The difference is what the audience on that surface has agreed to receive.
+
+This is why the same underlying process appears across documents, code, and experiences. The coordination question is not only what the artifact is. The coordination question is where it is exposed, to whom, and under what understood conditions.
 
 ## The Acceptance Gate
 
-Before a change enters the shared carrier (currently: merge to main in a public repo), it passes through an acceptance gate.
+Before a change enters a broader shared carrier, it passes through an acceptance gate.
 
-The acceptance gate is not supervision. It is a legibility checkpoint: is this change reviewable and understandable by any agent in the ecosystem, not just the agent that made it?
+The acceptance gate is not supervision. It is a legibility and consent checkpoint:
 
-The current mechanism is a pull request reviewed by at least one other agent before merge. The reviewer may be human, AI, or system. What matters is that the change is legible to someone other than its author.
+- is this change understandable by agents other than its author?
+- are the conditions of exposure appropriate for the next audience?
+- is the transition explicit enough that downstream agents remain coherent?
 
-The gate exists because the shared carrier is a context distribution surface. A change that enters it propagates to every downstream consumer. Legibility before merge is how downstream agents stay coherent.
+Today the most visible acceptance gate is often a pull request reviewed before merge. That is one gate form, not the model itself.
+
+A feature flag rollout, a documented promotion from working branch to shared reference, or publication to a downstream context consumer can also be acceptance gates.
 
 ## When System Agents Emerge
 
 A system agent is a crystallized learned pattern.
 
-The right time to introduce a system agent is after the pattern has been performed manually enough times — by human or AI agents — that:
+The right time to introduce a system agent is after a pattern has been performed manually enough times — by human agents or AI agents — that:
 
-1. the task is well understood
-2. the task is still the simplest answer
+1. the pattern is well understood
+2. it is still the simplest answer
 3. scripting it reduces friction without hiding meaning
 
-System agents should not be written in anticipation of a need. They should emerge from demonstrated patterns. An update script, a CI check, a build rule — these are system agents. They exist because the pattern they encode has been validated through use.
+System agents should not be written in anticipation of a need. They should emerge from demonstrated patterns.
+
+An update script, a continuous integration check, a build rule, or a context synchronization tool are all examples of system agents when they encode a pattern that has already proved useful.
 
 This is not a rule against automation. It is a rule against premature crystallization. A Rube Goldberg machine of automated steps that no agent fully understands is worse than a manual step that is visible and correctable.
 
@@ -109,26 +167,28 @@ This is not a rule against automation. It is a rule against premature crystalliz
 
 This model does not encode:
 
-- which agent type performs which task (that is capability-dependent and will shift)
-- a fixed sequence that must be followed (artifacts move between states in any direction)
-- a supervision hierarchy (all agents think, do, and teach to the best of their current capability)
-- a permanent carrier (Git is today's carrier; the coordination model applies regardless of carrier)
+- which agent type performs which task
+- a fixed sequence that must be followed
+- a supervision hierarchy
+- a permanent carrier
+- a requirement that Git be the long-term coordination substrate
 
 ## Consequences
 
 This model suggests that Milieu should evaluate its agent ecosystem not by asking whether the right specialist performed the right task, but by asking:
 
-- can any agent entering this state understand what came before?
+- can any agent entering this surface understand what came before?
 - can any agent observing this change understand what was accepted and why?
+- are the conditions of exposure explicit enough for the next audience?
 - are system agents emerging from learned patterns, or being constructed in anticipation?
 - are the loops tight enough that refinement is continuous rather than episodic?
 
 ## Open Questions
 
-- Which artifact states are currently most fragile under this model?
-- How should the coordination model be expressed when the carrier is not Git?
-- When a loop runs fast enough that intermediate artifact states are not explicitly recorded, what is the minimum trace that should be preserved?
-- How does this model interact with the context distribution question raised in REFERENCE-AGENTS-004 (milieu-public as a context distribution service)?
+- Which surfaces are currently most fragile under this model?
+- What minimum trace should be preserved when loops run too fast to record every intermediate step?
+- How should consent and exposure be signaled when the carrier is not Git?
+- How does this model interact with the context publishing question raised in REFERENCE-AGENTS-004?
 
 ## Related
 

--- a/references/REFERENCE-AGENTS-003-Agent-Coordination-Model.md
+++ b/references/REFERENCE-AGENTS-003-Agent-Coordination-Model.md
@@ -1,0 +1,139 @@
+# REFERENCE-AGENTS-003 — Agent Coordination Model
+
+- **ID:** REFERENCE-AGENTS-003
+- **Status:** Working Draft
+- **Created:** 2026-04-19
+- **Updated:** 2026-04-19
+
+## Intent
+
+Capture the working coordination model for how human agents, AI agents, and system agents move through the Milieu artifact states together.
+
+This reference sits alongside REFERENCE-AGENTS-001 (which describes the dimensions of an agentic ecosystem) and adds the practical coordination layer: how agents actually refine shared understanding across artifact states, what the acceptance gate means, and when system agents emerge.
+
+## Core Framing
+
+Milieu artifacts — RESOURCE, DECISION, ARCHITECTURE, code — are not pipeline deliverables passed between specialists.
+
+They are **states of shared understanding**.
+
+Any agent type can contribute to any artifact state. What changes across states is what kind of understanding is being refined, not which agent class is permitted to act.
+
+The actual distribution of work at any moment reflects current capability, not fixed role assignment. Today an AI agent may draft the bulk of an ARCHITECTURE document because that is where it can contribute most. A human agent may catch a constraint the AI missed. A system agent may enforce a boundary the build system understands and no one thought to specify explicitly. Tomorrow those distributions may shift.
+
+## Artifact States
+
+These are the current states of understanding in the Milieu record system. They are named after the record types that carry them.
+
+### Proposal (RESOURCE, Issue, or informal artifact)
+
+A need, observation, or idea that has not yet been refined into a shared commitment.
+
+The proposal state exists to surface something worth refining. It does not require a specific record type. A GitHub Issue, a REFERENCE document, a conversation thread, or a quick note may all carry a proposal.
+
+What must survive this state:
+- what is being observed or proposed
+- who has standing over it
+- known constraints arriving with it
+- pointers to related existing records
+
+### DECISION
+
+The state in which impacted stakeholders have refined a proposal into a shared commitment: what will be done and why, including what was explicitly left out.
+
+A DECISION is not authored by the agent that implements it. It is accepted by the agents with standing over the problem. The authoring agent (human, AI, or system) may produce the draft; acceptance is the act that matters.
+
+What must survive this state:
+- the reasoning, not just the conclusion
+- the constraints that propagate forward
+- what was weighed and set aside
+- which version was accepted and when
+
+### ARCHITECTURE
+
+The state in which the accepted commitment is translated into technical constraints and background sufficient for any agent to begin building without reconstructing intent.
+
+ARCHITECTURE documents are the primary context carrier for agents beginning implementation work. If an agent cannot observe the relevant ARCHITECTURE document, it should ask for it rather than invent its own constraints.
+
+What must survive this state:
+- the DECISION it implements (explicit relationship)
+- module or structural boundaries
+- what is host-specific versus genuinely general
+- open questions that remain unresolved
+
+### Code
+
+The state in which something actually exists and runs.
+
+Code is not the end of the loop. Observations from code — build results, test outcomes, unexpected behaviors — feed back into ARCHITECTURE and DECISION. The loop is continuous.
+
+What must survive this state:
+- which context versions (DECISION, ARCHITECTURE) the code was built against
+- what was tried and why
+- build and test results as evidence
+- open questions the code revealed
+
+## The Loops Are Tight
+
+These states are not phases with handoffs between them. They are positions an artifact can occupy, and agents move artifacts between positions continuously.
+
+The loop may run in seconds. An observation during a build may immediately refine an ARCHITECTURE constraint. A constraint in an ARCHITECTURE document may immediately prompt a revision to a DECISION. An agent may skip states in either direction.
+
+All agents are expected to refine as they go. The record system provides structure; it does not impose process latency.
+
+## The Acceptance Gate
+
+Before a change enters the shared carrier (currently: merge to main in a public repo), it passes through an acceptance gate.
+
+The acceptance gate is not supervision. It is a legibility checkpoint: is this change reviewable and understandable by any agent in the ecosystem, not just the agent that made it?
+
+The current mechanism is a pull request reviewed by at least one other agent before merge. The reviewer may be human, AI, or system. What matters is that the change is legible to someone other than its author.
+
+The gate exists because the shared carrier is a context distribution surface. A change that enters it propagates to every downstream consumer. Legibility before merge is how downstream agents stay coherent.
+
+## When System Agents Emerge
+
+A system agent is a crystallized learned pattern.
+
+The right time to introduce a system agent is after the pattern has been performed manually enough times — by human or AI agents — that:
+
+1. the task is well understood
+2. the task is still the simplest answer
+3. scripting it reduces friction without hiding meaning
+
+System agents should not be written in anticipation of a need. They should emerge from demonstrated patterns. An update script, a CI check, a build rule — these are system agents. They exist because the pattern they encode has been validated through use.
+
+This is not a rule against automation. It is a rule against premature crystallization. A Rube Goldberg machine of automated steps that no agent fully understands is worse than a manual step that is visible and correctable.
+
+## What This Model Does Not Encode
+
+This model does not encode:
+
+- which agent type performs which task (that is capability-dependent and will shift)
+- a fixed sequence that must be followed (artifacts move between states in any direction)
+- a supervision hierarchy (all agents think, do, and teach to the best of their current capability)
+- a permanent carrier (Git is today's carrier; the coordination model applies regardless of carrier)
+
+## Consequences
+
+This model suggests that Milieu should evaluate its agent ecosystem not by asking whether the right specialist performed the right task, but by asking:
+
+- can any agent entering this state understand what came before?
+- can any agent observing this change understand what was accepted and why?
+- are system agents emerging from learned patterns, or being constructed in anticipation?
+- are the loops tight enough that refinement is continuous rather than episodic?
+
+## Open Questions
+
+- Which artifact states are currently most fragile under this model?
+- How should the coordination model be expressed when the carrier is not Git?
+- When a loop runs fast enough that intermediate artifact states are not explicitly recorded, what is the minimum trace that should be preserved?
+- How does this model interact with the context distribution question raised in REFERENCE-AGENTS-004 (milieu-public as a context distribution service)?
+
+## Related
+
+- REFERENCE-AGENTS-000 — Agents Foundational View
+- REFERENCE-AGENTS-001 — Multi-Dimensional Agent Systems
+- REFERENCE-AGENTS-002 — Carried Context Working Concept
+- AGENTS.md
+- RECORD-001 — Record Types and Semantics

--- a/references/REFERENCE-AGENTS-004-Proposal-milieu-public-as-Context-Service.md
+++ b/references/REFERENCE-AGENTS-004-Proposal-milieu-public-as-Context-Service.md
@@ -1,4 +1,4 @@
-# REFERENCE-AGENTS-004 — Proposal: milieu-public as a Context Distribution Service
+# REFERENCE-AGENTS-004 — Proposal: milieu-public as Canonical Context Publisher
 
 - **ID:** REFERENCE-AGENTS-004
 - **Status:** Proposal — Needs Review
@@ -7,79 +7,87 @@
 
 ## Intent
 
-Surface a reframing of milieu-public's role that emerged during early subtree testing, and propose a DECISION be opened to settle it before the subtree pattern is adopted at scale.
+Surface a reframing of milieu-public's role that emerged during early subtree testing, and propose a DECISION be opened to settle it before the current pattern spreads.
 
-This document is a proposal, not a decision. It is written for Boss and any other agent with standing over milieu-public's architecture.
+This document is a proposal, not a decision. It is written for agents with standing over milieu-public's architecture and operating model.
 
 ## What Surfaced
 
 During the first subtree test (PrismalExperimental PR #1), a question emerged about where the vendor update script belongs.
 
-The script (`update-milieu-public.sh`) currently lives in PrismalExperimental — the downstream consumer. If milieu-public acquires more downstream consumers (other repos, RAG pipelines, model training corpora), each would need to independently know how to pull from milieu-public correctly. That is a coupling problem: every consumer encodes the carrier mechanics, not just the subscription intent.
+The script (`update-milieu-public.sh`) currently lives in PrismalExperimental — the downstream consumer. If milieu-public acquires more downstream consumers (other repos, retrieval systems, vector stores, model training corpora, or future carriers), each would need to independently know how to stay current with milieu-public correctly.
 
-The reframing: if milieu-public is a **context distribution service**, the update mechanics belong to the service, not to the consumers.
+That is a coupling problem. Every consumer ends up encoding carrier mechanics, not just subscription intent.
+
+## Proposed Reframing
+
+milieu-public appears to be evolving from a passive shared record archive toward a canonical context publisher.
+
+That does not yet require a heavy runtime service.
+
+It does suggest that milieu-public should own, or at least define, the canonical subscription pattern by which downstream consumers declare dependency and stay current.
 
 ## The Distinction
 
-### milieu-public as a shared record archive
+### milieu-public as shared record archive
 
 - holds documents
 - consumers figure out their own access patterns
-- no defined subscriber interface
+- no defined subscriber pattern
 - update mechanics are the consumer's problem
 
-### milieu-public as a context distribution service
+### milieu-public as canonical context publisher
 
 - holds documents
-- defines a subscriber interface: how a downstream consumer declares a dependency and stays current
-- owns the update mechanics (or at least the canonical form of them)
-- consumers declare intent, not implementation
+- defines a stable subscription pattern for downstream consumers
+- owns the canonical form of the update mechanics, even if the mechanics are lightweight
+- lets consumers declare intent, not invent their own distribution logic
 
-The difference matters most when carriers change. Git subtree is today's carrier. The same semantic pattern will be needed when the carrier is a RAG corpus, a vector store, or a model training dataset. If consumers own the mechanics, each carrier transition requires updating every consumer. If the service owns the interface, the transition is localized.
+The difference matters most when carriers change. Git subtree is today's carrier. The same semantic pattern may later need to support retrieval systems, vector stores, model training corpora, or other future carriers. If consumers own the mechanics, each carrier transition requires updating every consumer separately. If milieu-public owns the canonical pattern, the transition can stay localized.
 
 ## The Provenance Angle
 
-The subtree pattern gives each downstream consumer a versioned snapshot with a known commit hash. That commit hash is the current provenance primitive — it lets any agent (or any test run) say "I was operating against this specific version of shared context."
+The subtree pattern gives each downstream consumer a versioned snapshot with a known commit hash. That commit hash is the current provenance primitive. It lets any agent, run, or test result say: "I was operating against this specific version of shared context."
 
-This is especially important for multi-variant testing: if two model variants behave differently, the first question is whether they were trained or prompted against the same context version. Without provenance, that question cannot be answered.
+This matters immediately for comparison and debugging. If two model variants behave differently, or if two implementation branches diverge, the first question is whether they were operating against the same context version.
 
-The service framing extends this naturally: the service owns the version identifier, and every consumer's snapshot is traceable to it. Consumers do not need to invent their own versioning.
+The publisher framing extends this naturally: milieu-public owns the source version identifier, and every downstream snapshot remains traceable to it. Consumers do not need to invent their own provenance mechanism.
 
 ## What This Does Not Settle
 
-This proposal does not know:
+This proposal does not yet settle:
 
-- whether milieu-public should become a formal service with a defined interface, or whether a lighter convention (a canonical script location, a documented subscription pattern) is sufficient
-- whether the subtree mechanism is the right carrier long-term, or whether it is a good-enough starting point that a DECISION should ratify before replacing
-- how the service interface interacts with non-Git consumers (RAG, vector, model training)
-- whether a separate repo or a subdirectory within milieu-public is the right home for the subscriber interface
+- whether milieu-public should become a formal service with a defined interface, or whether a lighter convention is sufficient
+- whether Git subtree is the right long-term carrier, or just the current starting point
+- how the canonical subscription pattern should work for non-Git consumers
+- whether the update mechanics belong in a separate repo, a subdirectory within milieu-public, or another shared surface
 
-These are the questions that need Boss's input and likely a DECISION to settle.
+These questions need review and likely a DECISION.
 
 ## What the Test Already Showed
 
 PrismalExperimental PR #1 is a working test of the subtree pattern. It showed:
 
-- the vendored snapshot is legible to agents (the AGENTS.md update script guidance worked)
+- the vendored snapshot is legible to agents
 - the commit hash is present and attributable
 - the update script runs correctly
-- the PR gate on the downstream side controls when context updates are accepted
+- the downstream gate controls when context updates are accepted
 
-The test did not show whether this pattern scales cleanly to multiple consumers, or whether the script ownership question matters in practice yet.
+The test did not show whether the current ownership pattern scales cleanly to multiple consumers, or whether the canonical subscription pattern should live upstream yet.
 
-The recommendation is to treat PR #1 as evidence, not throwaway. The learning is real. The implementation may be revised by a DECISION, but the observations stand.
+The recommendation is to treat PR #1 as evidence, not throwaway. The learning is real even if the implementation pattern changes.
 
 ## What We Are Asking
 
-1. Is the service reframing the right mental model for milieu-public, or is there a better framing?
-2. Should a DECISION be opened to settle this before the subtree pattern spreads to more consumers?
-3. Where should the subscriber interface (update mechanics, canonical script or equivalent) live?
-4. Does the provenance requirement change how milieu-public should version its own snapshots?
+1. Is canonical context publisher the right framing for milieu-public, or is there a better one?
+2. Should a DECISION be opened now, before the current subtree pattern spreads further?
+3. Where should the canonical subscription pattern live?
+4. Does the provenance requirement change how milieu-public should version or package its own snapshots?
 
 ## Related
 
 - REFERENCE-AGENTS-002 — Carried Context (context propagation and provenance open questions)
 - REFERENCE-AGENTS-003 — Agent Coordination Model
-- PrismalExperimental PR #1 — first subtree test (vendored snapshot + update script)
+- PrismalExperimental PR #1 — first subtree test (vendored snapshot plus update script)
 - DECISION-OPERATIONS-CHANGE-000 — Change Proposals and Acceptance
 - DECISION-OPERATIONS-CHANGE-001 — Git-Based Change Proposal Workflow

--- a/references/REFERENCE-AGENTS-004-Proposal-milieu-public-as-Context-Service.md
+++ b/references/REFERENCE-AGENTS-004-Proposal-milieu-public-as-Context-Service.md
@@ -1,0 +1,85 @@
+# REFERENCE-AGENTS-004 — Proposal: milieu-public as a Context Distribution Service
+
+- **ID:** REFERENCE-AGENTS-004
+- **Status:** Proposal — Needs Review
+- **Created:** 2026-04-19
+- **Updated:** 2026-04-19
+
+## Intent
+
+Surface a reframing of milieu-public's role that emerged during early subtree testing, and propose a DECISION be opened to settle it before the subtree pattern is adopted at scale.
+
+This document is a proposal, not a decision. It is written for Boss and any other agent with standing over milieu-public's architecture.
+
+## What Surfaced
+
+During the first subtree test (PrismalExperimental PR #1), a question emerged about where the vendor update script belongs.
+
+The script (`update-milieu-public.sh`) currently lives in PrismalExperimental — the downstream consumer. If milieu-public acquires more downstream consumers (other repos, RAG pipelines, model training corpora), each would need to independently know how to pull from milieu-public correctly. That is a coupling problem: every consumer encodes the carrier mechanics, not just the subscription intent.
+
+The reframing: if milieu-public is a **context distribution service**, the update mechanics belong to the service, not to the consumers.
+
+## The Distinction
+
+### milieu-public as a shared record archive
+
+- holds documents
+- consumers figure out their own access patterns
+- no defined subscriber interface
+- update mechanics are the consumer's problem
+
+### milieu-public as a context distribution service
+
+- holds documents
+- defines a subscriber interface: how a downstream consumer declares a dependency and stays current
+- owns the update mechanics (or at least the canonical form of them)
+- consumers declare intent, not implementation
+
+The difference matters most when carriers change. Git subtree is today's carrier. The same semantic pattern will be needed when the carrier is a RAG corpus, a vector store, or a model training dataset. If consumers own the mechanics, each carrier transition requires updating every consumer. If the service owns the interface, the transition is localized.
+
+## The Provenance Angle
+
+The subtree pattern gives each downstream consumer a versioned snapshot with a known commit hash. That commit hash is the current provenance primitive — it lets any agent (or any test run) say "I was operating against this specific version of shared context."
+
+This is especially important for multi-variant testing: if two model variants behave differently, the first question is whether they were trained or prompted against the same context version. Without provenance, that question cannot be answered.
+
+The service framing extends this naturally: the service owns the version identifier, and every consumer's snapshot is traceable to it. Consumers do not need to invent their own versioning.
+
+## What This Does Not Settle
+
+This proposal does not know:
+
+- whether milieu-public should become a formal service with a defined interface, or whether a lighter convention (a canonical script location, a documented subscription pattern) is sufficient
+- whether the subtree mechanism is the right carrier long-term, or whether it is a good-enough starting point that a DECISION should ratify before replacing
+- how the service interface interacts with non-Git consumers (RAG, vector, model training)
+- whether a separate repo or a subdirectory within milieu-public is the right home for the subscriber interface
+
+These are the questions that need Boss's input and likely a DECISION to settle.
+
+## What the Test Already Showed
+
+PrismalExperimental PR #1 is a working test of the subtree pattern. It showed:
+
+- the vendored snapshot is legible to agents (the AGENTS.md update script guidance worked)
+- the commit hash is present and attributable
+- the update script runs correctly
+- the PR gate on the downstream side controls when context updates are accepted
+
+The test did not show whether this pattern scales cleanly to multiple consumers, or whether the script ownership question matters in practice yet.
+
+The recommendation is to treat PR #1 as evidence, not throwaway. The learning is real. The implementation may be revised by a DECISION, but the observations stand.
+
+## What We Are Asking
+
+1. Is the service reframing the right mental model for milieu-public, or is there a better framing?
+2. Should a DECISION be opened to settle this before the subtree pattern spreads to more consumers?
+3. Where should the subscriber interface (update mechanics, canonical script or equivalent) live?
+4. Does the provenance requirement change how milieu-public should version its own snapshots?
+
+## Related
+
+- REFERENCE-AGENTS-002 — Carried Context (context propagation and provenance open questions)
+- REFERENCE-AGENTS-003 — Agent Coordination Model
+- PrismalExperimental PR #1 — first subtree test (vendored snapshot + update script)
+- DECISION-OPERATIONS-CHANGE-000 — Change Proposals and Acceptance
+- DECISION-OPERATIONS-CHANGE-001 — Git-Based Change Proposal Workflow


### PR DESCRIPTION
## Summary

This PR refines the first pass of the coordination work from Issue #12.

Main changes:

- Rework `REFERENCE-AGENTS-003` to center the model on artifacts, surfaces, consent, and gates
- Keep `REFERENCE`, `DECISION`, and `ARCHITECTURE` as specialized artifact roles rather than rigid pipeline stages
- Broaden `Code` into `Implementation` so code, scripts, flags, configuration, and other executable artifacts fit naturally
- Reframe `REFERENCE-AGENTS-004` from service-first language toward `milieu-public` as a canonical context publisher with stable subscription patterns

## Why

The branch discussion surfaced two related problems:

1. Our coordination model was still too easy to read as a pipeline of handoffs
2. `milieu-public` was being described in language that risked implying a heavier runtime service than intended

This pass tries to keep the useful insights while reducing conceptual drift.

## Notes

- This is still working material, but it now feels ready for formal review rather than only branch-local refinement
- The key term to watch in review is probably `consent` in `REFERENCE-AGENTS-003`
- The key framing to watch in review is probably `canonical context publisher` in `REFERENCE-AGENTS-004`

## Related

- Closes none
- Related to Issue #12

~ contributors: Chris + GPT-5.4 Thinking