### PR TITLE
Refine Prismal Space minimum constraint foundation

### DIFF
--- a/references/REFERENCE-PRISMAL-000-Prismal-Space-Current-View-and-Open-Questions.md
+++ b/references/REFERENCE-PRISMAL-000-Prismal-Space-Current-View-and-Open-Questions.md
@@ -2,7 +2,7 @@
 
 - **ID:** REFERENCE-PRISMAL-000
 - **Status:** Working / Provisional Reference
-- **Created:** 2026-04-03
+- **Created:** 2026-03-06
 - **Updated:** 2026-04-27
 - **Scope:** Minimum constraint foundation and long-range simulation representation context for Prismal Space
 - **Related:** Prismal Starter exploration, multi-scale simulation research, REFERENCE-PRISMAL-GEOMETRY-000

--- a/references/REFERENCE-PRISMAL-000-Prismal-Space-Current-View-and-Open-Questions.md
+++ b/references/REFERENCE-PRISMAL-000-Prismal-Space-Current-View-and-Open-Questions.md
@@ -1,15 +1,15 @@
-# REFERENCE-PRISMAL-000
+# REFERENCE-PRISMAL-000 - Prismal Space - Current View and Open Questions
 
-## Prismal Space - Current View and Open Questions
-
+- **ID:** REFERENCE-PRISMAL-000
 - **Status:** Working / Provisional Reference
-- **Date:** 2026-04-27
+- **Created:** 2026-04-03
+- **Updated:** 2026-04-27
 - **Scope:** Minimum constraint foundation and long-range simulation representation context for Prismal Space
 - **Related:** Prismal Starter exploration, multi-scale simulation research, REFERENCE-PRISMAL-GEOMETRY-000
 
 ---
 
-# Intent
+## Intent
 
 This Reference Record captures the **current provisional view of Prismal™ and Prismal Space™** as it is presently understood.
 
@@ -23,7 +23,7 @@ Exploration work - including Prismal Starter - will generate evidence that may r
 
 ---
 
-# Scope
+## Scope
 
 This record addresses the **conceptual representation of simulation space across scales**.
 
@@ -50,7 +50,7 @@ Those decisions belong in project-level Decision Records and Architectural Decis
 
 ---
 
-# Minimum Constraint Foundation
+## Minimum Constraint Foundation
 
 Current exploration suggests that Prismal Space should not begin from coordinates, geometry, lattices, cells, or rendering. Those are derived representations or views.
 
@@ -86,7 +86,7 @@ This foundation is provisional. It exists to reduce premature commitment to any 
 
 ---
 
-# Current Provisional View
+## Current Provisional View
 
 Current exploration suggests that **Prismal Space may function as a bounded, observable constraint framework for organizing simulation state, transitions, observations, measures, and derived representations across multiple scales**.
 
@@ -94,11 +94,11 @@ Spatial, lattice, geometric, rendering, energy, information, and computational v
 
 Early work indicates several potential characteristics.
 
-## Multi-scale structure
+### Multi-scale structure
 
 Prismal Space appears suited to representing environments across multiple scale bands, ranging from human-scale interaction outward toward planetary or cosmic contexts and inward toward finer molecular, atomic, and quantum structures. We leave open the possibility the space may wrap around with yet unknown structures between Cosmic and Quantum.
 
-## Candidate reference structures
+### Candidate reference structures
 
 Early investigation suggests that some lattice and cell relationships may provide useful neighborhood, packing, alignment, and multi-scale organization properties.
 
@@ -106,13 +106,13 @@ Face-centered cubic relationships and rhombic dodecahedron cells remain importan
 
 Any candidate reference structure should be evaluated as a constraint family, measure space, embedding, authoring aid, or derived view rather than as the root ontology.
 
-## Reference structure rather than ultimate reality
+### Reference structure rather than ultimate reality
 
 A lattice representation should be treated as **one possible reference structure for organizing simulation**, not as the root definition of Prismal Space and not as a claim that physical reality must conform exactly to the lattice.
 
 Fields, flows, objects, and social constructs may cross, span, or ignore lattice boundaries.
 
-## Multiple representations may coexist
+### Multiple representations may coexist
 
 Simulation environments will likely involve several overlapping representations, including:
 
@@ -133,17 +133,17 @@ Prismal Space should not be reduced to any single representation layer. Lattice-
 
 ---
 
-# Durable Constraints We Suspect Matter
+## Durable Constraints We Suspect Matter
 
 Early exploration suggests several pressures that appear likely to remain relevant across projects. These should be treated as **guiding concerns**, not rigid rules.
 
-## Representation is not the world
+### Representation is not the world
 
 Spatial reference structures help organize simulation and computation but should not be mistaken for the complete ontology of the simulated world.
 
 Different phenomena may cross and/or span reference boundaries freely.
 
-## Multi-scale coherence
+### Multi-scale coherence
 
 The representation should support both:
 
@@ -152,7 +152,7 @@ The representation should support both:
 
 Ideally these operations preserve meaningful relationships across scale bands.
 
-## Relations and neighborhoods are fundamental
+### Relations and neighborhoods are fundamental
 
 Stable relation families appear central to many simulation tasks. Neighborhood relations are especially useful derived relations, but they should not be assumed to be purely geometric or spatial.
 
@@ -169,17 +169,17 @@ Relevant relation families may support:
 
 Structures that preserve consistent relation logic across scales may offer strong advantages.
 
-## Alignment legibility for authors
+### Alignment legibility for authors
 
 Builders, designers, and tool users must be able to **reason about alignment and placement**.
 
 Representations that are mathematically elegant but difficult to interpret may create long-term usability challenges.
 
-## Discrete composition may be preferable to ad-hoc correction
+### Discrete composition may be preferable to ad-hoc correction
 
 Where possible, lawful composition from discrete units may reduce the need for compensating geometry or alignment hacks.
 
-## Multiple authorities for different truths
+### Multiple authorities for different truths
 
 Different aspects of the world may require different authoritative sources, including:
 
@@ -192,7 +192,7 @@ Different aspects of the world may require different authoritative sources, incl
 
 These truths may overlap spatially but need not share the same storage model or update cadence.
 
-## Stable identity with derived local reference frames
+### Stable identity with derived local reference frames
 
 Any candidate indexing scheme should distinguish stable canonical identity from derived local reference frames used for computation, rendering, storage, or authoring.
 
@@ -206,19 +206,19 @@ This implies:
 
 This concern is independent of any specific runtime or engine implementation.
 
-## Rendering representation should not become canonical identity
+### Rendering representation should not become canonical identity
 
 Meshes, textures, and shaders are presentation layers. They should not become the canonical definition of simulation state.
 
 ---
 
-# Questions Active Explorations Should Help Answer
+## Questions Active Explorations Should Help Answer
 
 Several important questions remain unresolved.
 
 Exploration projects, including Prismal Starter, are expected to provide evidence that helps answer them.
 
-## What constitutes canonical identity?
+### What constitutes canonical identity?
 
 Possible candidates include:
 
@@ -233,7 +233,7 @@ Possible candidates include:
 
 The system may ultimately require more than one identity layer. Spatial identity may be one such layer, but it should not be assumed to be the root identity layer.
 
-## Which aspects of candidate reference structures are canonical, derived, or provisional?
+### Which aspects of candidate reference structures are canonical, derived, or provisional?
 
 It remains unclear which candidate structure properties should be treated as:
 
@@ -244,7 +244,7 @@ It remains unclear which candidate structure properties should be treated as:
 - authoring guidance
 - temporary exploration scaffold
 
-## How should scale bands compose and decompose?
+### How should scale bands compose and decompose?
 
 Questions include:
 
@@ -252,11 +252,11 @@ Questions include:
 - whether boundaries align across bands
 - how simulation meaning is preserved when transitioning between scales
 
-## What relation rules remain stable across scales?
+### What relation rules remain stable across scales?
 
 Certain adjacency or neighborhood rules may hold consistently across levels, while others may require translation. Other non-spatial relation families may also need stable cross-scale behavior.
 
-## How many representation layers are required in practice?
+### How many representation layers are required in practice?
 
 Candidate layers include:
 
@@ -271,23 +271,23 @@ Candidate layers include:
 
 Exploration will reveal which layers are necessary.
 
-## What should be stored as authoritative state?
+### What should be stored as authoritative state?
 
 Some structures may exist only as derived views. Others must be persisted as canonical simulation state.
 
 Understanding this boundary is important for distributed simulation and persistence.
 
-## How should rotation freedom be exposed to authors?
+### How should rotation freedom be exposed to authors?
 
 Placement flexibility introduces complexity in alignment reasoning. The system may require explicit rotation sets or policies to keep builder expectations clear.
 
-## Where do existing engine assumptions help or hinder?
+### Where do existing engine assumptions help or hinder?
 
 Existing engines and tools may provide strong capabilities but may also embed assumptions (for example, surface-centric geometry or Cartesian partitioning) that interact with Prismal Space in complex ways.
 
 ---
 
-# Expected Sources of Evidence
+## Expected Sources of Evidence
 
 Evidence informing this record may emerge from multiple exploration efforts, including:
 
@@ -304,7 +304,7 @@ Findings from these efforts should be referenced in project-level Decision Recor
 
 ---
 
-# Relationship to Project-Level Records
+## Relationship to Project-Level Records
 
 Projects such as Prismal Starter will produce their own Decision Records and Architectural Decision Records describing local implementation choices.
 
@@ -320,7 +320,7 @@ Project records should reference this document where relevant, especially when a
 
 ---
 
-# Consequences
+## Consequences
 
 Maintaining a provisional big-picture record allows:
 
@@ -333,7 +333,7 @@ This record should evolve as new insights emerge.
 
 ---
 
-# Review Triggers
+## Review Triggers
 
 This record should be revisited when significant findings occur, including:
 
@@ -345,7 +345,7 @@ This record should be revisited when significant findings occur, including:
 
 ---
 
-# Addendum A - Multiple Views of Simulation
+## Addendum A - Multiple Views of Simulation
 
 Prismal Space is currently better understood as a **bounded, observable constraint system** that may support multiple derived views of simulation.
 
@@ -357,7 +357,7 @@ This addendum is explanatory and provisional. It does not yet define a formal ar
 
 ---
 
-# Summary
+## Summary
 
 Prismal Space currently appears to be a **multi-scale constraint framework** that may support coherent simulation across bands of scale through bounded states, checkable constraints, lawful transitions, explicit observations, declared measures, and derived representations.
 

--- a/references/REFERENCE-PRISMAL-000-Prismal-Space-Current-View-and-Open-Questions.md
+++ b/references/REFERENCE-PRISMAL-000-Prismal-Space-Current-View-and-Open-Questions.md
@@ -2,10 +2,10 @@
 
 ## Prismal Space - Current View and Open Questions
 
--**Status:** Working / Provisional Reference
--**Date:** 2026-04-27
--**Scope:** Minimum constraint foundation and long-range simulation representation context for Prismal Space
--**Related:** Prismal Starter exploration, multi-scale simulation research, REFERENCE-PRISMAL-GEOMETRY-000
+- **Status:** Working / Provisional Reference
+- **Date:** 2026-04-27
+- **Scope:** Minimum constraint foundation and long-range simulation representation context for Prismal Space
+- **Related:** Prismal Starter exploration, multi-scale simulation research, REFERENCE-PRISMAL-GEOMETRY-000
 
 ---
 

--- a/references/REFERENCE-PRISMAL-000-Prismal-Space-Current-View-and-Open-Questions.md
+++ b/references/REFERENCE-PRISMAL-000-Prismal-Space-Current-View-and-Open-Questions.md
@@ -1,11 +1,11 @@
 # REFERENCE-PRISMAL-000
 
-## Prismal Space — Current View and Open Questions
+## Prismal Space - Current View and Open Questions
 
 **Status:** Working / Provisional Reference\
-**Date:** 2026-03-06\
-**Scope:** Long-range simulation representation context for Prismal Space\
-**Related:** Prismal Starter exploration, multi-scale simulation research
+**Date:** 2026-04-27\
+**Scope:** Minimum constraint foundation and long-range simulation representation context for Prismal Space\
+**Related:** Prismal Starter exploration, multi-scale simulation research, REFERENCE-PRISMAL-GEOMETRY-000
 
 ---
 
@@ -19,7 +19,7 @@ This record **is not a directive for implementation teams**. It does not prescri
 
 Instead, it provides a **big-picture reference** that teams may use when evaluating local decisions and experiments.
 
-Exploration work —- including Prismal Starter —- will generate evidence that may refine or replace the views expressed here.
+Exploration work - including Prismal Starter - will generate evidence that may refine or replace the views expressed here.
 
 ---
 
@@ -29,12 +29,14 @@ This record addresses the **conceptual representation of simulation space across
 
 It is concerned with:
 
-- spatial reference structures
+- minimum constraint foundations
+- spatial reference structures as derived views
 - multi-scale composition and decomposition
-- neighborhood relationships
+- neighborhood and other relation families
 - representation layering
 - alignment and authoring reasoning
 - simulation state representation
+- observation, measure, and quantity domains
 
 It does **not** define:
 
@@ -48,9 +50,47 @@ Those decisions belong in project-level Decision Records and Architectural Decis
 
 ---
 
+# Minimum Constraint Foundation
+
+Current exploration suggests that Prismal Space should not begin from coordinates, geometry, lattices, cells, or rendering. Those are derived representations or views.
+
+At the minimum foundation layer, Prismal Space is better understood as a **bounded, observable constraint system**.
+
+Minimum concepts:
+
+- **Boundary:** declared scope.
+- **Distinction:** observable difference.
+- **State:** arrangement of distinctions inside a boundary.
+- **Delta:** before-and-after difference between states; a candidate transition before constraints are applied.
+- **Constraint:** checkable limit on states or deltas.
+- **Transition:** a delta that is allowed under constraints.
+- **Observation:** recorded distinction about state, constraint, delta, or transition.
+- **Measure:** rule that assigns a quantity to something.
+- **Quantity:** measurable value with declared meaning.
+
+Derived concepts:
+
+- **Structure:** persistent constraint.
+- **Information:** observable distinction.
+- **Energy:** bounded capacity for transition.
+
+Consequences:
+
+- Coordinates are representations, not structure.
+- Geometry is interpretation under declared measures.
+- Rendering is observation or presentation, not canonical state.
+- Lattices are constraint families or derived views, not first principles.
+- No measure is implicit: distance, time, angle, scale, and coordinate basis must be declared where used.
+
+This foundation is provisional. It exists to reduce premature commitment to any single representation layer while preserving enough formal structure for implementation, testing, and review.
+
+---
+
 # Current Provisional View
 
-Current exploration suggests that **Prismal Space may function as a reference framework for organizing simulation across multiple scales**.
+Current exploration suggests that **Prismal Space may function as a bounded, observable constraint framework for organizing simulation state, transitions, observations, measures, and derived representations across multiple scales**.
+
+Spatial, lattice, geometric, rendering, energy, information, and computational views should be treated as derived lenses over that foundation unless a later record explicitly decides otherwise.
 
 Early work indicates several potential characteristics.
 
@@ -58,15 +98,17 @@ Early work indicates several potential characteristics.
 
 Prismal Space appears suited to representing environments across multiple scale bands, ranging from human-scale interaction outward toward planetary or cosmic contexts and inward toward finer molecular, atomic, and quantum structures. We leave open the possibility the space may wrap around with yet unknown structures between Cosmic and Quantum.
 
-## Reference geometry advantages
+## Candidate reference structures
 
-Early investigation suggests that **face-centered cubic (FCC) lattice relationships and rhombic dodecahedron cells** provide useful neighborhood and packing properties that may support coherent multi-scale organization.
+Early investigation suggests that some lattice and cell relationships may provide useful neighborhood, packing, alignment, and multi-scale organization properties.
 
-These geometries remain candidates for further exploration rather than settled conclusions.
+Face-centered cubic relationships and rhombic dodecahedron cells remain important candidates for exploration, but they should not be treated as the starting assumption for Prismal Space.
+
+Any candidate reference structure should be evaluated as a constraint family, measure space, embedding, authoring aid, or derived view rather than as the root ontology.
 
 ## Reference structure rather than ultimate reality
 
-The lattice representation should be treated as **a reference structure for organizing simulation**, not as a claim that physical reality must conform exactly to the lattice.
+A lattice representation should be treated as **one possible reference structure for organizing simulation**, not as the root definition of Prismal Space and not as a claim that physical reality must conform exactly to the lattice.
 
 Fields, flows, objects, and social constructs may cross, span, or ignore lattice boundaries.
 
@@ -74,16 +116,20 @@ Fields, flows, objects, and social constructs may cross, span, or ignore lattice
 
 Simulation environments will likely involve several overlapping representations, including:
 
+- constraint systems
 - spatial reference structures
+- lattice-oriented views
 - volumetric or material fields
 - discrete objects and agents
+- energy and information views
+- computational representations
 - rendering geometry
 - authoring grids or alignment guides
 - streaming or storage partitions
 
-These representations may share spatial anchors without necessarily sharing the same data model.\
-\
-Prismal Space represents the lattice-oriented spatial view of the simulation. Other views—such as energy, information, or computational representations—may coexist and be navigated between for different purposes.
+These representations may share anchors or identities without necessarily sharing the same data model.
+
+Prismal Space should not be reduced to any single representation layer. Lattice-oriented spatial views, energy views, information views, computational views, rendering views, storage views, and authoring views may each expose different aspects of the same underlying constraint system.
 
 ---
 
@@ -106,9 +152,11 @@ The representation should support both:
 
 Ideally these operations preserve meaningful relationships across scale bands.
 
-## Neighborhood relations are fundamental
+## Relations and neighborhoods are fundamental
 
-Stable adjacency relationships appear central to many simulation tasks, including:
+Stable relation families appear central to many simulation tasks. Neighborhood relations are especially useful derived relations, but they should not be assumed to be purely geometric or spatial.
+
+Relevant relation families may support:
 
 - propagation
 - interaction
@@ -116,8 +164,10 @@ Stable adjacency relationships appear central to many simulation tasks, includin
 - partitioning
 - streaming
 - navigation
+- identity preservation
+- view derivation
 
-Structures that preserve consistent neighborhood logic across scales may offer strong advantages.
+Structures that preserve consistent relation logic across scales may offer strong advantages.
 
 ## Alignment legibility for authors
 
@@ -142,15 +192,15 @@ Different aspects of the world may require different authoritative sources, incl
 
 These truths may overlap spatially but need not share the same storage model or update cadence.
 
-## Stable identity with local reference frames
+## Stable identity with derived local reference frames
 
-Any candidate spatial indexing scheme should support **stable canonical spatial identity together with derived local reference frames used for computation**.
+Any candidate indexing scheme should distinguish stable canonical identity from derived local reference frames used for computation, rendering, storage, or authoring.
 
-Large simulations cannot assume a single global computational coordinate frame with sufficient numerical precision for all purposes. Rendering, simulation, and interaction systems will often operate within **local reference frames** derived from canonical spatial identity.
+Large simulations cannot assume a single global computational coordinate frame with sufficient numerical precision for all purposes. Rendering, simulation, and interaction systems will often operate within **local reference frames** derived from canonical identity.
 
 This implies:
 
-- canonical spatial identity should remain stable even when computational frames change
+- canonical identity should remain stable even when computational frames change
 - systems should be able to operate within local frames suited to their precision needs
 - candidate indexing approaches should be evaluated partly by how well they support **change of reference frame across scale bands**
 
@@ -166,26 +216,33 @@ Meshes, textures, and shaders are presentation layers. They should not become th
 
 Several important questions remain unresolved.
 
-Exploration projects—including Prismal Starter—are expected to provide evidence that helps answer them.
+Exploration projects, including Prismal Starter, are expected to provide evidence that helps answer them.
 
-## What constitutes canonical spatial identity?
+## What constitutes canonical identity?
 
 Possible candidates include:
 
+- constraint identifiers
+- state identifiers
+- transition identifiers
+- observation identifiers
 - lattice coordinate systems
 - hierarchical cell identifiers
 - region aggregates
 - multi-scale spatial addresses
 
-The system may ultimately require more than one identity layer.
+The system may ultimately require more than one identity layer. Spatial identity may be one such layer, but it should not be assumed to be the root identity layer.
 
-## Which aspects of the lattice are reference only?
+## Which aspects of candidate reference structures are canonical, derived, or provisional?
 
-It remains unclear which lattice properties should be treated as:
+It remains unclear which candidate structure properties should be treated as:
 
-- canonical spatial structure
+- canonical structure
+- derived view
+- measure convention
 - computational convenience
 - authoring guidance
+- temporary exploration scaffold
 
 ## How should scale bands compose and decompose?
 
@@ -195,20 +252,22 @@ Questions include:
 - whether boundaries align across bands
 - how simulation meaning is preserved when transitioning between scales
 
-## What neighborhood rules remain stable across scales?
+## What relation rules remain stable across scales?
 
-Certain adjacency rules may hold consistently across levels, while others may require translation.
+Certain adjacency or neighborhood rules may hold consistently across levels, while others may require translation. Other non-spatial relation families may also need stable cross-scale behavior.
 
 ## How many representation layers are required in practice?
 
 Candidate layers include:
 
-- canonical spatial reference
+- canonical constraint system
+- spatial reference views
 - simulation fields
 - object placement
 - navigation abstraction
 - rendering geometry
 - streaming partitions
+- authoring surfaces
 
 Exploration will reveal which layers are necessary.
 
@@ -280,17 +339,17 @@ This record should be revisited when significant findings occur, including:
 
 - major discoveries from Prismal Starter
 - successful multi-scale simulation prototypes
-- evidence that canonical spatial identity requires redefinition
+- evidence that canonical identity requires redefinition
 - evidence that representation layering must change
 - strong performance or usability findings affecting spatial representation
 
 ---
 
-# Addendum A — Multiple Views of Simulation
+# Addendum A - Multiple Views of Simulation
 
-Prismal Space currently represents the **lattice-oriented spatial view** of the simulation.
+Prismal Space is currently better understood as a **bounded, observable constraint system** that may support multiple derived views of simulation.
 
-Other views—such as **energy**, **information**, or **computational** views—may also be necessary for different purposes. A given phenomenon may be easier to simulate, reason about, optimize, or render from one view than another.
+Spatial and lattice views, energy views, information views, computational views, rendering views, storage views, and authoring views may each be necessary for different purposes. A given phenomenon may be easier to simulate, reason about, optimize, or render from one view than another.
 
 This does not imply separate realities. It suggests that the same underlying simulation may need to be understood through multiple lenses, with lawful ways to navigate between them while preserving identity, meaning, and relevant constraints.
 
@@ -300,13 +359,15 @@ This addendum is explanatory and provisional. It does not yet define a formal ar
 
 # Summary
 
-Prismal Space currently appears to be a **multi-scale spatial reference framework** that may support coherent simulation across bands of scale.
+Prismal Space currently appears to be a **multi-scale constraint framework** that may support coherent simulation across bands of scale through bounded states, checkable constraints, lawful transitions, explicit observations, declared measures, and derived representations.
 
-However, the precise form of that framework—and how it interacts with fields, objects, rendering systems, and authoring tools—remains an open question.
+Spatial and lattice representations remain important candidate views, but they are no longer treated as the minimum foundation.
+
+The precise form of that framework, and how it interacts with fields, objects, rendering systems, and authoring tools, remains an open question.
 
 Active exploration projects are expected to generate the evidence necessary to refine this understanding.
 
 This record exists to **preserve shared orientation while that exploration proceeds**.
 
-© 2011–present Milieu.Us — All rights reserved.
+© 2011-present Milieu.Us - All rights reserved.
 Milieu™, Prismal™, and Prismal Space™ are trademarks of Milieu.Us.

--- a/references/REFERENCE-PRISMAL-000-Prismal-Space-Current-View-and-Open-Questions.md
+++ b/references/REFERENCE-PRISMAL-000-Prismal-Space-Current-View-and-Open-Questions.md
@@ -2,10 +2,10 @@
 
 ## Prismal Space - Current View and Open Questions
 
-**Status:** Working / Provisional Reference\
-**Date:** 2026-04-27\
-**Scope:** Minimum constraint foundation and long-range simulation representation context for Prismal Space\
-**Related:** Prismal Starter exploration, multi-scale simulation research, REFERENCE-PRISMAL-GEOMETRY-000
+-**Status:** Working / Provisional Reference
+-**Date:** 2026-04-27
+-**Scope:** Minimum constraint foundation and long-range simulation representation context for Prismal Space
+-**Related:** Prismal Starter exploration, multi-scale simulation research, REFERENCE-PRISMAL-GEOMETRY-000
 
 ---
 


### PR DESCRIPTION
## Summary

This pull request refines `REFERENCE-PRISMAL-000` so the minimum foundation for Prismal Space is introduced before any specific lattice or geometry candidate.

Key changes:

- Adds a `Minimum Constraint Foundation` section.
- Defines the minimum concepts: Boundary, Distinction, State, Delta, Constraint, Transition, Observation, Measure, and Quantity.
- Defines Structure, Information, and Energy as derived concepts.
- Reframes face-centered cubic relationships and rhombic dodecahedron cells as candidate reference structures rather than starting assumptions.
- Generalizes spatial/lattice language into derived views over a bounded, observable constraint system.
- Updates open questions from canonical spatial identity toward broader canonical identity.

## Intent

This addresses a current misunderstanding risk where agents may read the reference as implying:

```text
Prismal Space = face-centered cubic / rhombic dodecahedron lattice
```

The revised intended reading is:

```text
Prismal Space = bounded, observable constraint framework
spatial/lattice/geometric views = derived representations or candidate reference structures
```

## Review Notes

This is a focused conceptual update, not a full RECORDS compliance or style pass.