### PR TITLE
Proposal: DECISION-MILIEU-WEB-001 Phase Zero Web Presence

### DIFF
--- a/decisions/DECISION-MILIEU-WEB-001-Phase-Zero-Web-Presence.md
+++ b/decisions/DECISION-MILIEU-WEB-001-Phase-Zero-Web-Presence.md
@@ -1,0 +1,152 @@
+# DECISION-MILIEU-WEB-001 - Phase Zero Web Presence
+
+- **ID:** DECISION-MILIEU-WEB-001
+- **Status:** Proposal
+- **Created:** 2026-05-20
+- **Updated:** 2026-05-20
+- **Proposed by:** Dao Shen
+
+---
+
+## Intent
+
+Establish a lightweight, participatory web presence for Milieu that serves as the first threshold into shared worlding practice — not a product launch, not a marketing campaign, and not a passive brochure.
+
+The site should function as a two-way learning surface: visitors engage through small acts of practice, teach us what will resonate with their communities, and discover new ways of entering the work themselves.
+
+---
+
+## Context
+
+Milieu is building environments for shared worlding — participatory storytelling spaces where guides, world builders, players, witnesses, and chroniclers co-create persistent worlds together. Before those environments are fully realized, the team needs:
+
+- A public threshold that attracts the right early communities and filters mismatched expectations.
+- A structured way to learn from people who already practice participatory storytelling in their own communities.
+- A foundation for discovering participation styles and needs that cannot be anticipated in advance.
+- A practice surface that models, from the start, what Milieu values: co-creation, consent, emergence, and contribution over consumption.
+
+Two small communities are currently in view as early collaborators — one organized around an aspiring professional tabletop game master with a mixed niche tabletop roleplay and MMO audience, one organized around a charismatic academic with a high-conceptual participant base. These groups represent genuinely different participation styles and will teach different things. Additional communities will be identified and invited in structured cohorts as capabilities develop.
+
+The web presence is Phase Zero of a longer community-building progression. It precedes and informs the subsequent phases of validating the core practice framework, building facilitation infrastructure, and inviting a wider network of communities.
+
+This is a proposal. Nothing here mandates what will be built. The objective is to invite review, surface open questions, and gain alignment before any implementation begins.
+
+---
+
+## Proposed Objectives
+
+Phase Zero has five learning objectives, not deliverables:
+
+1. **Attract the right communities** — participatory storytelling groups with existing facilitation, worldbuilding, or shared narrative practice. Not just audiences. Not just fans. People who already practice together.
+
+2. **Learn participation styles** — discover what kinds of prompts, roles, rhythms, and structures resonate with different groups before trying to build for them.
+
+3. **Learn participation needs** — surface what individuals and communities are looking for that they cannot currently find, including group fit, facilitation style, tone, and safety structures.
+
+4. **Model Milieu values** — the site itself should demonstrate what Milieu is: a place of practice, response, and co-creation rather than scripted performance or presentation.
+
+5. **Build matching capacity** — identify both existing communities and individuals seeking communities, and explore whether anonymous peer-resonance signals can help connect compatible participants over time.
+
+---
+
+## Proposed Approach
+
+Interest is shown at Milieu through practice, not declaration.
+
+Visitors engage not by filling out an inquiry form but by completing a small act of participation — responding to a prompt, rewriting a scene fragment, proposing a worldbuilding constraint, navigating a facilitation dilemma, or describing a witnessing experience that changed them. These acts are designed to be meaningful in themselves, not just intake mechanisms.
+
+The site should serve visitors as much as it serves Milieu. Someone who completes a participation prompt should come away having thought about their own practice in a new way, discovered a role they had not considered, or encountered language that names something they already do.
+
+Those who wish to continue can indicate:
+- Whether they come alone or with a community
+- If alone: what they are looking for in a group
+- If with a community: what they practice together
+- What kind of first session would feel right (one-night, short arc, ongoing world)
+- Whether they would like to anonymously hear from others seeking similar things
+
+Anonymous peer resonance is opt-in and explicit. Contact information is never shared without separate, specific consent.
+
+---
+
+## Proposed Site Structure
+
+The following is a proposed information architecture, not a specification. Sections, language, and interaction design are all subject to review and revision.
+
+### Section 1 — What Milieu Is
+A short manifesto: what the project is, what it is not, and what kind of participation it is building toward.
+
+### Section 2 — What We Are Practicing
+The shared practice frame: participatory storytelling as co-creation, facilitation as holding space, worldbuilding as emergent systems, consent as infrastructure, persistence as accumulated meaning.
+
+### Section 3 — Ways to Enter
+Participation roles presented as modes of presence, not fixed identities or job descriptions. Proposed initial roles include Guide, World Builder, Player, Witness, Chronicler, and Steward. Each role should describe its charge, desire, tension, instruments, contribution to others, and boundary — what the role must never become.
+
+Role language deliberately avoids "casting" terminology to prevent confusion with physical theater or film production contexts.
+
+### Section 4 — First Act of Participation
+A small set of participation prompts visitors may choose from. Each prompt is designed to:
+- Surface a different participation style or storytelling tradition
+- Teach Milieu something actionable about what that person or community needs
+- Give the visitor something of value in return — a new way of seeing their own practice
+
+Proposed prompts include:
+- **Role Reflection** — describe a moment when you inhabited something like one of the roles
+- **Threshold Rewrite** — extend or rewrite a moment from a Milieu scene fragment
+- **Worldbuilding Constraint** — propose one rule for a small shared world and explain why it matters
+- **Facilitation Dilemma** — respond to a moment of player hesitation as a Guide
+- **Witnessing Practice** — describe a moment from someone else's story that changed how you think about observing
+
+These are starting proposals. The team should evaluate, replace, or extend them based on what we actually want to learn.
+
+### Section 5 — Continue the Conversation
+A structured follow-up for those who wish to stay in contact. Fields proposed above under Proposed Approach. Participation is voluntary. Anonymous peer resonance is a separate, explicit opt-in.
+
+---
+
+## What This Proposal Does Not Decide
+
+- What the site looks like visually
+- What technology stack it uses
+- How responses are stored, reviewed, or acted on
+- How peer resonance signals are aggregated or shared
+- When the site opens to the public versus remaining internal
+- How many or which specific communities are invited first
+- What the facilitation framework for Phase 1 sessions will look like
+- How roles are refined based on what Phase Zero teaches
+
+Those questions are downstream of this proposal. Some will require their own decisions.
+
+---
+
+## Open Questions
+
+- Are the five Phase Zero objectives the right ones, or should any be reordered, added, or removed?
+- Are the proposed roles the right initial set, or are there missing or redundant modes?
+- Are the proposed participation prompts well-matched to what we most need to learn?
+- How should responses be reviewed — who sees them, how often, and in what form?
+- What is the threshold for moving from Phase Zero to Phase 1? What would need to be true?
+- Should some responses be visible to later visitors (with permission)? What would that surface design look like?
+- How is anonymous peer resonance implemented safely and without creating obligations we cannot fulfill?
+- What is the internal review loop — who evaluates what Phase Zero teaches, how often, and with what artifact?
+
+---
+
+## Consequences
+
+If this proposal moves forward:
+
+- Milieu will have a public threshold before any full participation infrastructure exists, which creates expectations that must be managed carefully.
+- Early visitors' responses will shape Phase 1 facilitation design and community selection criteria.
+- The site commits Milieu to treating community members as co-designers from the first moment of contact.
+- Anonymous peer resonance, if implemented, creates a light obligation to follow through on connections in a meaningful timeframe.
+- The site will require ongoing attention — not as a publishing channel but as a living learning surface.
+
+---
+
+## Related
+
+- `DECISION-MILIEU-CORE-Foundational-Constraints.md`
+- `DECISION-MILIEU-MVM-000` — Minimum Viable Milieu
+- `DECISION-MVE-000` — Minimum Viable Experience
+- `DECISION-MVE-STAKEHOLDERS-000` — MVE Stakeholders
+- `DECISION-OPERATIONS-CHANGE-000` — Change Proposals and Acceptance


### PR DESCRIPTION
## Summary

Adds `DECISION-MILIEU-WEB-001 - Phase Zero Web Presence` to the `decisions/` directory.

This is a proposal. Nothing here mandates what will be built. The objective is to invite review, surface open questions, and gain alignment before any implementation begins.

## What this proposal covers

- Intent and context for a Phase Zero participatory web presence
- Five learning objectives (not deliverables)
- Proposed approach: interest shown through practice, not declaration
- Proposed site structure (information architecture, not specification)
- Explicit list of what this proposal does not decide
- Open questions for team review
- Consequences if the proposal moves forward

## Related decisions

- `DECISION-MILIEU-CORE-Foundational-Constraints.md`
- `DECISION-MILIEU-MVM-000`
- `DECISION-MVE-000`
- `DECISION-MVE-STAKEHOLDERS-000`
- `DECISION-OPERATIONS-CHANGE-000`

---

_Discussion surface via Issues to follow._